### PR TITLE
DOC: Generate markdown reference documentation

### DIFF
--- a/dagrunner/runner/schedulers/dask.py
+++ b/dagrunner/runner/schedulers/dask.py
@@ -5,6 +5,7 @@ All have in common that they convert the provided workflow dictionary into a
 dask graph by initiating a dask Delayed container on each node and then
 executing it (by calling its compute method) using the specified scheduler.
 See the following useful background reading:
+
     - https://docs.dask.org/en/latest/scheduler-overview.html
     - https://docs.dask.org/en/latest/scheduling.html
     - https://docs.dask.org/en/latest/delayed.html
@@ -22,7 +23,7 @@ from dask.distributed import (
 
 
 def no_op(*args, **kwargs):
-    """Dummy operation for our dask graph See :func:`add_dummy_tasks`"""
+    """Dummy operation for our dask graph See [add_dummy_tasks](#add_dummy_tasks)"""
     pass
 
 
@@ -40,13 +41,13 @@ def add_dummy_tasks(dask_graph):
     effectively ensures that no data leaves the worker.
 
     Args:
-        dask_graph: Dask graph dict
+    - dask_graph (dict): Dask graph dict
 
     Returns:
-        Dask graph dict
+    - dict: Dask graph
 
     TODO:
-    Potentially skip intermediate dummy for tasks with no return value.
+    - Potentially skip intermediate dummy for tasks with no return value.
     """
     pred_deps, succ_deps = get_deps(dask_graph)
     # Determine termination nodes for each branch

--- a/dagrunner/utils/logger.py
+++ b/dagrunner/utils/logger.py
@@ -1,0 +1,223 @@
+"""
+This module takes much from the Python logging cookbook:
+https://docs.python.org/3/howto/logging-cookbook.html#sending-and-receiving-logging-events-across-a-network
+
+- client_attach_socket_handler, a function that attaches a socket handler to the root
+  logger.
+- ServerContext, a context manager that starts and manages the TCP server on its own
+  thread to receive log records.
+"""
+import logging, logging.handlers
+import pickle
+import socket
+import socketserver
+import struct
+import threading
+import queue
+
+
+__all__ = ['client_attach_socket_handler', 'ServerContext']
+
+
+def client_attach_socket_handler():
+    """
+    Attach a SocketHandler instance to the root logger at the sending end.
+
+    Now, we can log to the root logger, or any other logger. First the root...
+        logging.info('Jackdaws love my big sphinx of quartz.')
+
+    Now, define a couple of other loggers which might represent areas in your
+    application:
+
+        logger1 = logging.getLogger('myapp.area1')
+        logger2 = logging.getLogger('myapp.area2')
+
+        logger1.debug('Quick zephyrs blow, vexing daft Jim.')
+        logger1.info('How quickly daft jumping zebras vex.')
+        logger2.warning('Jail zesty vixen who grabbed pay from quack.')
+        logger2.error('The five boxing wizards jump quickly.')
+    """
+    rootLogger = logging.getLogger('')
+    rootLogger.setLevel(logging.DEBUG)
+    socketHandler = logging.handlers.SocketHandler('localhost',
+                        logging.handlers.DEFAULT_TCP_LOGGING_PORT)
+    # don't bother with a formatter, since a socket handler sends the event as
+    # an unformatted pickle
+    rootLogger.addHandler(socketHandler)
+
+
+class LogRecordStreamHandler(socketserver.StreamRequestHandler):
+    """
+    Handler for a streaming logging request.
+
+    This basically logs the record using whatever logging policy is
+    configured locally.
+    """
+
+    def handle(self):
+        """
+        Handle multiple requests - each expected to be a 4-byte length,
+        followed by the LogRecord in pickle format. Logs the record
+        according to whatever policy is configured locally.
+        """
+        while True:
+            chunk = self.connection.recv(4)
+            if len(chunk) < 4:
+                break
+            slen = struct.unpack('>L', chunk)[0]
+            chunk = self.connection.recv(slen)
+            while len(chunk) < slen:
+                chunk = chunk + self.connection.recv(slen - len(chunk))
+            obj = self.unPickle(chunk)
+            record = logging.makeLogRecord(obj)
+            # Modify record to include hostname
+            record.hostname = socket.gethostname()
+            self.handleLogRecord(record)
+
+            # Push log record to the queue for database writing
+            self.server.log_queue.put(record)
+
+    def unPickle(self, data):
+        return pickle.loads(data)
+
+    def handleLogRecord(self, record):
+        # if a name is specified, we use the named logger rather than the one
+        # implied by the record.
+        if self.server.logname is not None:
+            name = self.server.logname
+        else:
+            name = record.name
+        logger = logging.getLogger(name)
+        # N.B. EVERY record gets logged. This is because Logger.handle
+        # is normally called AFTER logger-level filtering. If you want
+        # to do filtering, do it at the client end to save wasting
+        # cycles and network bandwidth!
+        logger.handle(record)
+
+
+class LogRecordSocketReceiver(socketserver.ThreadingTCPServer):
+    """
+    Simple TCP socket-based logging receiver.
+    """
+
+    allow_reuse_address = True
+
+    def __init__(self, host='localhost',
+                 port=logging.handlers.DEFAULT_TCP_LOGGING_PORT,
+                 handler=LogRecordStreamHandler, log_queue=None):
+        socketserver.ThreadingTCPServer.__init__(self, (host, port), handler)
+        self.abort = 0
+        self.timeout = 1
+        self.logname = None
+        self.log_queue = log_queue  # Store the reference to the log queue
+
+    def serve_until_stopped(self, queue_handler=None):
+        import select
+        abort = 0
+        while not abort:
+            rd, wr, ex = select.select([self.socket.fileno()],
+                                       [], [],
+                                       self.timeout)
+            if rd:
+                self.handle_request()
+                queue_handler.write(self.log_queue)
+            abort = self.abort
+        queue_handler.close()
+
+    def stop(self):
+        self.server_close()  # Close the server socket
+        self.abort = 1  # Set abort flag to stop the server loop
+
+
+class SQLiteQueueHandler:
+    def __init__(self, sqfile='logs.sqlite'):
+        self._sqfile = sqfile
+        self._conn = None
+
+    @property
+    def db(self):
+        if self._conn is None:
+            import sqlite3
+            self._conn = sqlite3.connect(self._sqfile)  # Connect to the SQLite database
+            cursor = self._conn.cursor()
+            cursor.execute("""
+                CREATE TABLE IF NOT EXISTS logs (
+                    created TEXT,
+                    name TEXT,
+                    level TEXT,
+                    message TEXT,
+                    hostname TEXT,
+                    process TEXT,
+                    thread TEXT
+                )
+            """)  # Create the 'logs' table if it doesn't exist
+        return self._conn
+
+    def write(self, log_queue):
+        while not log_queue.empty():
+            record = log_queue.get()
+            print("Dequeued item:", record)
+            cursor = self.db.cursor()
+            cursor.execute("""
+                INSERT INTO logs (created, name, level, message, hostname, process, thread)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+            """, (record.created, record.name, record.levelname, record.getMessage(), record.hostname, record.process, record.thread))
+            self.db.commit()  # Commit the transaction
+        
+    def close(self):
+        if self._conn:
+            self._conn.close()
+
+
+class ServerContext:
+    """
+    Start a TCP server to receive log records.
+
+    First run the server, and then the client. On the client side, nothing is printed
+    on the console; on the server side, you should see log messages printed to the
+    console.  The TC server is run in a separate thread enabling the main thread to
+    continue running other tasks.
+
+    Log format is:
+    %(relativeCreated)5d %(name)-15s %(levelname)-8s %(hostname)s %(process)d %(asctime)s %(message)s
+
+    """
+    def __init__(self, sqlite_filepath=None):
+        self.tcpserver = None
+        self.server_thread = None
+
+    def __enter__(self):
+        logging.basicConfig(
+            format='%(relativeCreated)5d %(name)-15s %(levelname)-8s %(hostname)s %(process)d %(asctime)s %(message)s',
+            datefmt="%Y-%m-%dT%H:%M:%S")  # Date in ISO 8601 format
+        
+        self.log_queue = queue.Queue()
+
+        sqlitequeue = None
+        if sqlite_filepath:
+            sqlitequeue = SQLiteQueueHandler(sqfile=sqlite_filepath)
+
+        self.tcpserver = LogRecordSocketReceiver(log_queue=self.log_queue)
+        print('About to start TCP server...')
+        self.server_thread = threading.Thread(target=self.tcpserver.serve_until_stopped, kwargs={'queue_handler': sqlitequeue})
+        self.server_thread.start()
+
+        return self.server_thread, self.tcpserver
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.tcpserver.stop()
+        self.server_thread.join()
+
+
+def main():
+    """
+    Demonstrate how to start a TCP server to receive log records.
+    """
+    with ServerContext():
+        print("Doing something while the server is running")
+        input("Press Enter to stop the server...")
+    print("Server stopped")
+
+
+if __name__ == '__main__':
+    main()

--- a/docs/dagrunner.execute_graph.md
+++ b/docs/dagrunner.execute_graph.md
@@ -9,7 +9,7 @@
 ### Call Signature:
 
 ```python
-ExecuteGraph(networkx_graph: str, plugin_executor: <built-in function callable> = <function plugin_executor at 0x7ff38bf8ab90>, scheduler: str = 'processes', num_workers: int = 1, profiler_filepath: str = None, dry_run: bool = False, verbose: bool = False, **kwargs)
+ExecuteGraph(networkx_graph: str, plugin_executor: <built-in function callable> = <function plugin_executor at 0x7ff0e42c2b00>, scheduler: str = 'processes', num_workers: int = 1, profiler_filepath: str = None, dry_run: bool = False, verbose: bool = False, **kwargs)
 ```
 
 see [NodeAwarePlugin](dagrunner.plugin_framework.md#NodeAwarePlugin)

--- a/docs/dagrunner.execute_graph.md
+++ b/docs/dagrunner.execute_graph.md
@@ -1,0 +1,75 @@
+# Module: `dagrunner.execute_graph`
+
+[Source](../dagrunner/execute_graph.py#L0)
+
+# Class: `ExecuteGraph`
+
+[Source](../dagrunner/execute_graph.py#L149)
+
+### Call Signature:
+
+```python
+ExecuteGraph(networkx_graph: str, plugin_executor: <built-in function callable> = <function plugin_executor at 0x7ff38bf8ab90>, scheduler: str = 'processes', num_workers: int = 1, profiler_filepath: str = None, dry_run: bool = False, verbose: bool = False, **kwargs)
+```
+
+see [NodeAwarePlugin](dagrunner.plugin_framework.md#NodeAwarePlugin)
+
+see [ObjectAsStr](dagrunner.utils.md#ObjectAsStr)
+
+# Object: `SCHEDULERS`
+
+# Class: `SkipBranch`
+
+[Source](../dagrunner/execute_graph.py#L30)
+
+This exception is used to skip a branch of the execution graph.
+
+To be used in combination to one of the multiprocessing schedulers.
+In the single-threaded scheduler, Dask executes tasks sequentially, and
+exceptions will propagate as they occur, potentially halting the execution of
+subsequent tasks.
+
+see [TimeIt](dagrunner.utils.md#TimeIt)
+
+see [function_to_argparse](dagrunner.utils.md#function_to_argparse)
+
+# Function: `main`
+
+[Source](../dagrunner/execute_graph.py#L240)
+
+### Call Signature:
+
+```python
+main()
+```
+
+Entry point of the program.
+Parses command line arguments and executes the graph using the ExecuteGraph class.
+
+# Function: `plugin_executor`
+
+[Source](../dagrunner/execute_graph.py#L43)
+
+### Call Signature:
+
+```python
+plugin_executor(*args, call=None, verbose=False, dry_run=False, **kwargs)
+```
+
+Executes a plugin function or method with the provided arguments and keyword arguments.
+
+Args:
+    *args: Positional arguments to be passed to the plugin function or method.
+    call: A tuple containing the callable object or python dot path to one, and its keyword arguments.
+    verbose: A boolean indicating whether to print verbose output.
+    dry_run: A boolean indicating whether to perform a dry run without executing the plugin.
+    **kwargs: Keyword arguments to be passed to the plugin function or method (common to all plugins).
+
+Returns:
+    The result of executing the plugin function or method.
+
+Raises:
+    ValueError: If the `call` argument is not provided.
+
+see [visualise_graph](dagrunner.utils.visualisation.md#visualise_graph)
+

--- a/docs/dagrunner.md
+++ b/docs/dagrunner.md
@@ -1,0 +1,16 @@
+# Module: `dagrunner`
+
+[Source](../dagrunner/__init__.py#L0)
+
+see [dagrunner.plugin_framework](dagrunner.plugin_framework.md#dagrunner.plugin_framework)
+
+see [DataPolling](dagrunner.plugin_framework.md#DataPolling)
+
+see [Input](dagrunner.plugin_framework.md#Input)
+
+see [NodeAwarePlugin](dagrunner.plugin_framework.md#NodeAwarePlugin)
+
+see [Plugin](dagrunner.plugin_framework.md#Plugin)
+
+see [Shell](dagrunner.plugin_framework.md#Shell)
+

--- a/docs/dagrunner.plugin_framework.md
+++ b/docs/dagrunner.plugin_framework.md
@@ -1,0 +1,64 @@
+# Module: `dagrunner.plugin_framework`
+
+[Source](../dagrunner/plugin_framework.py#L0)
+
+# Class: `DataPolling`
+
+[Source](../dagrunner/plugin_framework.py#L49)
+
+### Call Signature:
+
+```python
+DataPolling()
+```
+
+Abstract base class to define our plugin UI
+
+# Class: `Input`
+
+[Source](../dagrunner/plugin_framework.py#L96)
+
+### Call Signature:
+
+```python
+Input()
+```
+
+A plugin that is of type instructed to be passed node parameters
+
+# Class: `NodeAwarePlugin`
+
+[Source](../dagrunner/plugin_framework.py#L21)
+
+### Call Signature:
+
+```python
+NodeAwarePlugin()
+```
+
+A plugin that is of type instructed to be passed node parameters
+
+# Class: `Plugin`
+
+[Source](../dagrunner/plugin_framework.py#L13)
+
+### Call Signature:
+
+```python
+Plugin()
+```
+
+Abstract base class to define our plugin UI
+
+# Class: `Shell`
+
+[Source](../dagrunner/plugin_framework.py#L29)
+
+### Call Signature:
+
+```python
+Shell()
+```
+
+Abstract base class to define our plugin UI
+

--- a/docs/dagrunner.runner.md
+++ b/docs/dagrunner.runner.md
@@ -1,0 +1,6 @@
+# Module: `dagrunner.runner`
+
+[Source](../dagrunner/runner/__init__.py#L0)
+
+see [dagrunner.runner.schedulers](dagrunner.runner.schedulers.md#dagrunner.runner.schedulers)
+

--- a/docs/dagrunner.runner.schedulers.asyncmp.md
+++ b/docs/dagrunner.runner.schedulers.asyncmp.md
@@ -1,0 +1,20 @@
+# Module: `dagrunner.runner.schedulers.asyncmp`
+
+[Source](../dagrunner/runner/schedulers/asyncmp.py#L0)
+
+# Class: `AsyncMP`
+
+[Source](../dagrunner/runner/schedulers/asyncmp.py#L12)
+
+### Call Signature:
+
+```python
+AsyncMP(nprocesses, *args, fail_fast=True, profiler_filepath=None, **kwargs)
+```
+
+Basic asynchronous scheduler using python built-in multiprocessing.
+
+Context manager for creating a pool of workers, submits jobs based on the
+condition of their dependencies completing, then finally tidies up after
+itself.
+

--- a/docs/dagrunner.runner.schedulers.base.md
+++ b/docs/dagrunner.runner.schedulers.base.md
@@ -1,0 +1,4 @@
+# Module: `dagrunner.runner.schedulers.base`
+
+[Source](../dagrunner/runner/schedulers/base.py#L0)
+

--- a/docs/dagrunner.runner.schedulers.dask.md
+++ b/docs/dagrunner.runner.schedulers.dask.md
@@ -1,0 +1,87 @@
+# Module: `dagrunner.runner.schedulers.dask`
+
+[Source](../dagrunner/runner/schedulers/dask.py#L0)
+
+Standardised UI for dask compatible schedulers (including 'dask on ray')
+
+All have in common that they convert the provided workflow dictionary into a
+dask graph by initiating a dask Delayed container on each node and then
+executing it (by calling its compute method) using the specified scheduler.
+See the following useful background reading:
+
+    - https://docs.dask.org/en/latest/scheduler-overview.html
+    - https://docs.dask.org/en/latest/scheduling.html
+    - https://docs.dask.org/en/latest/delayed.html
+
+# Class: `DaskOnRay`
+
+[Source](../dagrunner/runner/schedulers/dask.py#L156)
+
+### Call Signature:
+
+```python
+DaskOnRay(num_workers, profiler_filepath=None, **kwargs)
+```
+
+# Class: `Distributed`
+
+[Source](../dagrunner/runner/schedulers/dask.py#L76)
+
+### Call Signature:
+
+```python
+Distributed(num_workers, profiler_filepath=None, **kwargs)
+```
+
+# Class: `SingleMachine`
+
+[Source](../dagrunner/runner/schedulers/dask.py#L107)
+
+### Call Signature:
+
+```python
+SingleMachine(num_workers, scheduler='processes', profiler_filepath=None, **kwargs)
+```
+
+# Function: `add_dummy_tasks`
+
+[Source](../dagrunner/runner/schedulers/dask.py#L30)
+
+### Call Signature:
+
+```python
+add_dummy_tasks(dask_graph)
+```
+
+Add a terminating dummy task to the graph as well as to each of our
+disconnected branches.
+
+A terminating dummy node is added to our graph to allow us to run the
+complete graph in one call as well as discard the return.
+Dummy nodes (as denoted by 'waiter' prefix in their name) are also added
+to the termination of each independent branch, as a single terminal task
+on the graph would gather all data (as its input) on the single worker and
+potentially blow past its limits. That is, one dummy task per output
+effectively ensures that no data leaves the worker.
+
+Args:
+- dask_graph (dict): Dask graph dict
+
+Returns:
+- dict: Dask graph
+
+TODO:
+- Potentially skip intermediate dummy for tasks with no return value.
+
+# Function: `no_op`
+
+[Source](../dagrunner/runner/schedulers/dask.py#L25)
+
+### Call Signature:
+
+```python
+no_op(*args, **kwargs)
+```
+
+Dummy operation for our dask graph See [add_dummy_tasks](#add_dummy_tasks)
+

--- a/docs/dagrunner.runner.schedulers.md
+++ b/docs/dagrunner.runner.schedulers.md
@@ -1,0 +1,10 @@
+# Module: `dagrunner.runner.schedulers`
+
+[Source](../dagrunner/runner/schedulers/__init__.py#L0)
+
+see [dagrunner.runner.schedulers.asyncmp](dagrunner.runner.schedulers.asyncmp.md#dagrunner.runner.schedulers.asyncmp)
+
+see [dagrunner.runner.schedulers.dask](dagrunner.runner.schedulers.dask.md#dagrunner.runner.schedulers.dask)
+
+# Object: `SCHEDULERS`
+

--- a/docs/dagrunner.utils.md
+++ b/docs/dagrunner.utils.md
@@ -1,0 +1,40 @@
+# Module: `dagrunner.utils`
+
+[Source](../dagrunner/utils/__init__.py#L0)
+
+see [dagrunner.utils.visualisation](dagrunner.utils.visualisation.md#dagrunner.utils.visualisation)
+
+# Class: `ObjectAsStr`
+
+[Source](../dagrunner/utils/__init__.py#L10)
+
+### Call Signature:
+
+```python
+ObjectAsStr(obj, name=None)
+```
+
+Hide object under a string.
+
+# Class: `TimeIt`
+
+[Source](../dagrunner/utils/__init__.py#L34)
+
+### Call Signature:
+
+```python
+TimeIt(verbose=False)
+```
+
+# Function: `function_to_argparse`
+
+[Source](../dagrunner/utils/__init__.py#L92)
+
+### Call Signature:
+
+```python
+function_to_argparse(func, parser=None, exclude=None)
+```
+
+Generate an argparse from a function signature
+

--- a/docs/dagrunner.utils.visualisation.md
+++ b/docs/dagrunner.utils.visualisation.md
@@ -1,0 +1,46 @@
+# Module: `dagrunner.utils.visualisation`
+
+[Source](../dagrunner/utils/visualisation.py#L0)
+
+Module responsible for scheduler independent graph visualisation
+
+# Class: `MermaidGraph`
+
+[Source](../dagrunner/utils/visualisation.py#L54)
+
+### Call Signature:
+
+```python
+MermaidGraph()
+```
+
+# Class: `MermaidHTML`
+
+[Source](../dagrunner/utils/visualisation.py#L79)
+
+### Call Signature:
+
+```python
+MermaidHTML(graph)
+```
+
+# Function: `visualise_graph`
+
+[Source](../dagrunner/utils/visualisation.py#L202)
+
+### Call Signature:
+
+```python
+visualise_graph(graph, output_filepath)
+```
+
+Args:
+    graph (dict):
+        Graph with keys representing 'targets' and values representing
+        (function, *args).
+    output_filepath (str):
+        Node graph visualisation html output filepath.
+
+Returns:
+    None:
+

--- a/docs/gen_docs
+++ b/docs/gen_docs
@@ -1,0 +1,144 @@
+import inspect
+import importlib
+import os
+import sys
+
+
+def gen_source_link(obj, target_root):
+    source_link = inspect.getsourcefile(obj)
+    source_link = os.path.relpath(os.path.realpath(source_link), os.path.realpath(target_root))
+    source_line = inspect.getsourcelines(obj)[1]
+    return f"[Source]({source_link}#L{source_line})\n\n"
+
+
+def get_obj_module_dot_path(obj):
+    if inspect.ismodule(obj):
+        return obj.__name__
+    elif hasattr(obj, "__module__"):
+        return obj.__module__
+    return None
+
+
+def gen_obj_link(obj):
+    module_path = get_obj_module_dot_path(obj)
+    return f"see [{obj.__name__}]({module_path}.md#{obj.__name__})\n\n"
+
+
+def is_private(obj_name):
+    return obj_name.startswith("_") and not obj_name.endswith("__")
+
+
+def external_dependency(obj, root_package):
+    ret = False
+    module_path = get_obj_module_dot_path(obj)
+    if module_path:
+        ret = module_path.split(".")[0] != root_package
+    return ret
+
+
+def no_include(obj, module_name):
+    """
+    Returns True if the object should not be included in the documentation.
+    
+    If any of the following conditions are met:
+    - Definition lives outside the module and is not a private module.
+    """
+    ret = False
+    module_path = get_obj_module_dot_path(obj)
+    if module_path:
+        ret = module_path != module_name and not module_path.startswith("_")
+    return ret
+
+
+def gen_heading(level, text, obj=None, obname=""):
+    if obj and obname:
+        obname = f" `{obname}`"
+    return f"{'#' * level} {text}:{obname}\n\n"
+
+
+def gen_obj_markdown(level, heading_name, obj, obname, target_root):
+    markdown = gen_heading(1, heading_name, obj, obname)
+    if inspect.isclass(obj) or inspect.isfunction(obj) or inspect.ismodule(obj):
+        markdown += gen_source_link(obj, target_root)
+        try:
+            call_signature = inspect.signature(obj)
+            if call_signature:
+                markdown += gen_heading(level+1, "Call Signature")
+                markdown += f"```python\n{obname}{str(call_signature)}\n```\n\n"
+        except (AttributeError, ValueError, TypeError):
+            pass
+        obj_doc = inspect.getdoc(obj)
+        if obj_doc:
+            markdown += f"{obj_doc}\n\n"
+    return markdown
+
+
+def prioritised_get_members(module):
+    for member in inspect.getmembers(module, inspect.ismodule):
+        yield member
+    for member in inspect.getmembers(module):
+        if not inspect.ismodule(member[1]):
+            yield member
+
+
+def generate_markdown_from_module(module_name, target_root):
+    root_package = module_name.split('.')[0]
+
+    module = importlib.import_module(module_name)
+    markdown = gen_obj_markdown(1, "Module", module, module.__name__, target_root)
+
+    for name, obj in prioritised_get_members(module):
+        if external_dependency(obj, root_package) or is_private(name) or inspect.ismethod(obj) or inspect.isbuiltin(obj) or (name.startswith("_") and name.startswith("_") and name.endswith("__")):
+            continue
+        obname = "Class" if inspect.isclass(obj) else "Function" if inspect.isfunction(obj) else "Module" if inspect.ismodule(obj) else "Object"
+        if no_include(obj, module_name):
+            markdown += gen_obj_link(obj)
+        else:
+            markdown += gen_obj_markdown(2, obname, obj, name, target_root)
+
+        if inspect.isclass(obj):
+            for cls_member_name, cls_member in inspect.getmembers(obj, inspect.ismethod):
+                if is_private(cls_member_name):
+                    continue
+                markdown += gen_obj_markdown(3, "Method", cls_member_name, cls_member_name, target_root)
+    return markdown
+
+
+def path_to_module(abs_path, base_path):
+    relative_path = os.path.relpath(abs_path, base_path)
+    module_path = relative_path.replace(os.path.sep, ".")
+    module_path = module_path.replace(".py", "")
+    return module_path
+
+
+def gen_markdown(module_dot_path, target_root):
+    markdown_content = generate_markdown_from_module(module_dot_path, target_root)
+    output_file = os.path.join(target_root, f"{module_dot_path}.md")
+    with open(output_file, "w") as f:
+        f.write(markdown_content)
+    print(f"Markdown file '{output_file}' generated successfully!")
+
+
+def generate_markdown_recursive(module_dot_path, target_root):
+    module = importlib.import_module(module_dot_path)
+    base_path = os.path.dirname(importlib.import_module(module_dot_path.split('.')[0]).__path__[0])
+    module_path = module.__path__[0]
+    for dirpath, _, filenames in os.walk(module.__path__[0]):
+        if os.path.basename(dirpath).startswith("_") or "tests" in dirpath:
+            continue
+        module_dot_path = path_to_module(dirpath, base_path)
+        if importlib.util.find_spec(module_dot_path):
+            print(f"{module_dot_path} is a subpackage")
+            gen_markdown(module_dot_path, target_root)
+        for filename in filenames:
+            if not filename.startswith('_') and filename.endswith(".py"):
+                module_path = os.path.join(dirpath, filename)
+                module_dot_path = path_to_module(module_path, base_path)
+                print(f"{module_dot_path} is a module")
+                gen_markdown(module_dot_path, target_root)
+
+
+if __name__ == "__main__":
+    module_path = sys.argv[1]
+    target_root = os.path.abspath(sys.argv[2])
+    generate_markdown_recursive(module_path, target_root)

--- a/docs/gen_docs
+++ b/docs/gen_docs
@@ -21,7 +21,8 @@ def get_obj_module_dot_path(obj):
 
 def gen_obj_link(obj):
     module_path = get_obj_module_dot_path(obj)
-    return f"see [{obj.__name__}]({module_path}.md#{obj.__name__})\n\n"
+    obname = obj.__name__
+    return f"[{module_path}]({module_path}.md#{obname})"
 
 
 def is_private(obj_name):
@@ -83,25 +84,28 @@ def prioritised_get_members(module):
 
 def generate_markdown_from_module(module_name, target_root):
     root_package = module_name.split('.')[0]
+    links = []
 
     module = importlib.import_module(module_name)
     markdown = gen_obj_markdown(1, "Module", module, module.__name__, target_root)
+    links.append(gen_obj_link(module))
 
     for name, obj in prioritised_get_members(module):
         if external_dependency(obj, root_package) or is_private(name) or inspect.ismethod(obj) or inspect.isbuiltin(obj) or (name.startswith("_") and name.startswith("_") and name.endswith("__")):
             continue
         obname = "Class" if inspect.isclass(obj) else "Function" if inspect.isfunction(obj) else "Module" if inspect.ismodule(obj) else "Object"
         if no_include(obj, module_name):
-            markdown += gen_obj_link(obj)
+            markdown += f"see {gen_obj_link(obj)} \n\n"
         else:
             markdown += gen_obj_markdown(2, obname, obj, name, target_root)
+            links.append(gen_obj_link(obj))
 
         if inspect.isclass(obj):
             for cls_member_name, cls_member in inspect.getmembers(obj, inspect.ismethod):
                 if is_private(cls_member_name):
                     continue
                 markdown += gen_obj_markdown(3, "Method", cls_member_name, cls_member_name, target_root)
-    return markdown
+    return markdown, links
 
 
 def path_to_module(abs_path, base_path):
@@ -112,7 +116,7 @@ def path_to_module(abs_path, base_path):
 
 
 def gen_markdown(module_dot_path, target_root):
-    markdown_content = generate_markdown_from_module(module_dot_path, target_root)
+    markdown_content, links = generate_markdown_from_module(module_dot_path, target_root)
     output_file = os.path.join(target_root, f"{module_dot_path}.md")
     with open(output_file, "w") as f:
         f.write(markdown_content)


### PR DESCRIPTION
Motivation here is an experiment to generate markdown reference documentation, taking advantage of the native support for markdown via github.  This is hoped to make syntax, building and maintaining documentation much more lightweight and easier than the alternatives (sphinx).

- [x] Generate markdown files for each module.
- [x] Link to source code.
- [x] Link to markdown anchors.
- [ ] Automate build using github actions.
- [ ] Index TOC generation.

## Issues

- https://github.com/MetOffice/improver_suite/issues/2079

![image](https://github.com/MetOffice/dagrunner/assets/2071643/7e638cf8-5aea-4ace-be4c-6bf833d89050)
