### PR TITLE
BUG: Fixed argparse and docbuild

### DIFF
--- a/dagrunner/__init__.py
+++ b/dagrunner/__init__.py
@@ -4,4 +4,4 @@
 # See LICENSE in the root of the repository for full licensing details.
 from .plugin_framework import Plugin, Shell, Input, DataPolling, NodeAwarePlugin
 
-__version__ = "0.0.1"
+__version__ = "0.0.1dev"

--- a/dagrunner/execute_graph.py
+++ b/dagrunner/execute_graph.py
@@ -170,31 +170,31 @@ class ExecuteGraph:
         Execute a networkx graph using a chosen scheduler.
 
         Args:
-        - networkx_graph (networkx.DiGraph, callable or str):
+        - `networkx_graph` (networkx.DiGraph, callable or str):
           A networkx graph; dot path to a networkx graph or callable that returns 
-        - one (str); tuple representing (edges, nodes) or callable object that
+          one; tuple representing (edges, nodes) or callable object that
           returns a networkx.
-        - plugin_executor (callable):
+        - `plugin_executor` (callable):
           A callable object that executes a plugin function or method with the provided
           arguments and keyword arguments.  By default, uses the `plugin_executor` function.
           Optional.
-        - scheduler (str):
+        - `scheduler` (str):
           Accepted values include "ray", "multiprocessing" and those recognised
           by dask: "threads", "processes" and "single-threaded" (useful for debugging).
           See https://docs.dask.org/en/latest/scheduling.html.  Optional.
-        - num_workers (int):
+        - `num_workers` (int):
           Number of processes or threads to use.  Optional.
-        - dry_run (bool):
+        - `dry_run` (bool):
           Print executed commands but don't actually run them.  Optional.
-        - profiler_filepath (str):
+        - `profiler_filepath` (str):
           Output html profile filepath if supported by the chosen scheduler.
           See https://docs.dask.org/en/latest/diagnostics-local.html
           Optional.
-        - verbose (bool):
+        - `verbose` (bool):
           Print executed commands.  Optional.
-        - sqlite_filepath (str):
+        - `sqlite_filepath` (str):
           Filepath to a SQLite database to store log records.  Optional.
-        - **kwargs:
+        - `**kwargs`:
           Optional global keyword arguments to apply to all applicable plugins.
         """
         self._nxgraph = _get_networkx(networkx_graph)

--- a/dagrunner/tests/utils/test_docstring_parse.py
+++ b/dagrunner/tests/utils/test_docstring_parse.py
@@ -1,0 +1,111 @@
+from dagrunner.utils import docstring_parse
+import pytest
+from dagrunner.utils import docstring_parse
+
+
+def markdown_style(arg1, arg2=None):
+    """
+    Summary line.
+
+    Extended description of function.
+
+    Args:
+    - `arg1` (int): Description of arg1
+      further description.
+    - `arg2` (str): Description of arg2, defaults to None
+
+    Returns:
+    - bool: Description of return value
+
+    """
+    return True
+
+
+def rst_style(arg1, arg2=None):
+    """
+    Summary line.
+
+    Extended description of function.
+
+    :param arg1: Description of arg1
+        further description.
+    :type arg1: int
+    :param arg2: Description of arg2, defaults to None
+    :type arg2: str, optional
+
+    :return: Description of return value
+    :rtype: bool
+    """
+    return True
+
+
+def google_style(arg1, arg2=None):
+    """
+    Summary line.
+
+    Extended description of function.
+
+    Args:
+        arg1 (int): Description of arg1
+            further description.
+        arg2 (str, optional): Description of arg2, defaults to None
+
+    Returns:
+        bool: Description of return value
+
+    """
+    return True
+
+
+def numpy_style(arg1, arg2=None):
+    """
+    Summary line.
+
+    Extended description of function.
+
+    Parameters
+    ----------
+    arg1 : int
+        Description of arg1
+        further description.
+    arg2 : str, optional
+        Description of arg2, defaults to None
+
+    Returns
+    -------
+    bool
+        Description of return value
+
+    """
+    return True
+
+
+def non_style():
+    """
+    Summary line.
+
+    Extended description of function.
+    """
+    return True
+
+
+def non_style_v2():
+    """Summary line.
+
+    Extended description of function.
+    """
+    return True
+
+
+@pytest.mark.parametrize("func", [numpy_style, google_style, rst_style, markdown_style])
+def test_docstring_parse(func):
+    intro_lines, arg_mapping = docstring_parse(func)
+    assert intro_lines == "Summary line.\n\nExtended description of function."
+    assert arg_mapping == {"arg1": "Description of arg1 further description.", "arg2": "Description of arg2, defaults to None"}
+
+
+@pytest.mark.parametrize("func", [non_style, non_style_v2])
+def test_docstring_parse_no_style(func):
+    intro_lines, arg_mapping = docstring_parse(func)
+    assert intro_lines == "Summary line.\n\nExtended description of function."
+    assert arg_mapping == {}

--- a/dagrunner/utils/_doc_styles.py
+++ b/dagrunner/utils/_doc_styles.py
@@ -1,0 +1,166 @@
+# (C) Crown Copyright, Met Office. All rights reserved.
+#
+# This file is part of 'dagrunner' and is released under the BSD 3-Clause license.
+# See LICENSE in the root of the repository for full licensing details.
+from abc import ABC, abstractmethod
+
+
+class DocstringParser(ABC):
+    def __init__(self, doc):
+        self._doc = self.remove_docstring_padding(doc, skip_first=True)
+        self._desc = ""
+        self._var_lookup = {}
+
+    @classmethod
+    @abstractmethod
+    def is_style(cls, doc):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def description(self):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def variable_mapping(self):
+        raise NotImplementedError
+
+    @staticmethod
+    def remove_docstring_padding(doc, skip_first=False):
+        if isinstance(doc, str):
+            doc = doc.split('\n')
+        # Determine docstring padding
+        if not doc[0].strip():
+            doc = doc[1:]  # empty line so remove it
+        start_indx = 0
+        if skip_first and not doc[0].startswith(" "):
+            start_indx = 1
+        for dd in doc[start_indx:]:
+            if dd.strip() and dd.startswith(" "):
+                padding = len(dd) - len(dd.lstrip())
+                break
+            elif dd.strip() and not dd.startswith(" "):
+                padding = 0
+                break
+    
+        # Remove docstring padding
+        for dind in range(len(doc)):
+            if not doc[dind][:padding].strip():
+                doc[dind] = doc[dind][padding:].rstrip()
+            elif not doc[dind].strip():
+                doc[dind] = ""
+            else:
+                doc[dind] = doc[dind].rstrip()
+        return doc
+    
+    @staticmethod
+    def infer_multiline(doc):
+        ndoc = ""
+        for dd in doc:
+            if dd.startswith(' '):
+                ndoc += f" {dd.strip()}"
+            else:
+                ndoc += '\n' + dd if ndoc else dd.strip()
+        return ndoc.split('\n')
+        #return '\n'.join(doc).replace('\n' + ' '*padding, ' ').split('\n')
+    
+    @staticmethod
+    def get_index(doc, startswith=None, endswith=None):
+        ret = None
+        for ind, dd in enumerate(doc):
+            if ((startswith and dd.startswith(startswith)) or (endswith and dd.endswith(endswith))):
+                ret = ind
+                break
+        return ret
+
+
+class GoogleStyle(DocstringParser):
+    @classmethod
+    def is_style(cls, doc):
+        doc = '\n'.join(cls.remove_docstring_padding(doc))
+        return "Args:\n    " in doc or "Returns:\n    " in doc
+
+    @property
+    def description(self):
+        if not self._desc:
+            dind = self.get_index(self._doc, endswith=':')
+            self._desc = '\n'.join(self._doc[:dind]).rstrip()
+        return self._desc
+
+    @property
+    def variable_mapping(self):
+        if not self._var_lookup:
+            args = self._doc[self._doc.index('Args:')+1:]
+            args = args[:args.index("")]
+            args = self.remove_docstring_padding(args)
+            self._var_lookup = {line.split('(')[0].strip(): ':'.join(line.split(':')[1:]).strip() for line in self.infer_multiline(args)}
+        return self._var_lookup
+
+
+class NumpyStyle(DocstringParser):
+    @classmethod
+    def is_style(cls, doc):
+        doc = '\n'.join(cls.remove_docstring_padding(doc))
+        return "Parameters\n----------\n" in doc or "Returns\n-------\n" in doc
+
+    @property
+    def description(self):
+        if not self._desc:
+            dind = self.get_index(self._doc, startswith='--')
+            self._desc = '\n'.join(self._doc[:dind-2]).rstrip()
+        return self._desc
+
+    @property
+    def variable_mapping(self):
+        if not self._var_lookup:
+            args = self._doc[self._doc.index('Parameters')+2:]
+            args = args[:args.index("")]
+            args = [f"{arg.split(':')[0]}:" if not arg.startswith(" ") and ':' in arg else arg for arg in args]
+            self._var_lookup = {line.split(':')[0].strip(): ':'.join(line.split(':')[1:]).strip() for line in self.infer_multiline(args)}
+        return self._var_lookup
+
+
+class RSTStyle(DocstringParser):
+    @classmethod
+    def is_style(cls, doc):
+        return ":param " in doc or ":return:" in doc
+
+    @property
+    def description(self):
+        if not self._desc:
+            dind = self.get_index(self._doc, startswith=':')
+            self._desc = '\n'.join(self._doc[:dind]).rstrip()
+        return self._desc
+
+    @property
+    def variable_mapping(self):
+        if not self._var_lookup:
+            name = ":param"
+            dind = self.get_index(self._doc, name)
+            args = self._doc[dind:]
+            args = args[:args.index("")]
+            self._var_lookup = {line.split(name)[1].split(':')[0].strip(): ':'.join(line.split(name)[1].split(':')[1:]).strip() for line in self.infer_multiline(args) if line.startswith(name)}
+        return self._var_lookup
+
+
+class MDStyle(DocstringParser):
+    @classmethod
+    def is_style(cls, doc):
+        doc = '\n'.join(cls.remove_docstring_padding(doc))
+        return "Args:\n- " in doc or "Returns:\n- " in doc
+
+    @property
+    def description(self):
+        if not self._desc:
+            dind = self.get_index(self._doc, endswith=':')
+            self._desc = '\n'.join(self._doc[:dind]).rstrip()
+        return self._desc
+
+    @property
+    def variable_mapping(self):
+        if not self._var_lookup:
+            args = self._doc[self._doc.index('Args:')+1:]
+            args = args[:args.index("")]
+            self._var_lookup = {line.split(':')[0].split(' ')[1].replace('`',''): ':'.join(line.split(':')[1:]).strip() for line in self.infer_multiline(args)}
+        return self._var_lookup

--- a/dagrunner/utils/logger.py
+++ b/dagrunner/utils/logger.py
@@ -2,9 +2,9 @@
 This module takes much from the Python logging cookbook:
 https://docs.python.org/3/howto/logging-cookbook.html#sending-and-receiving-logging-events-across-a-network
 
-- client_attach_socket_handler, a function that attaches a socket handler to the root
+- `client_attach_socket_handler`, a function that attaches a socket handler to the root
   logger.
-- ServerContext, a context manager that starts and manages the TCP server on its own
+- `ServerContext`, a context manager that starts and manages the TCP server on its own
   thread to receive log records.
 """
 import logging, logging.handlers
@@ -50,8 +50,8 @@ class LogRecordStreamHandler(socketserver.StreamRequestHandler):
     """
     Handler for a streaming logging request.
 
-    This basically logs the record using whatever logging policy is
-    configured locally.
+    Specialisation of the `socketserver.StreamRequestHandler` class to handle log
+    records and customise logging events.
     """
 
     def handle(self):
@@ -98,6 +98,9 @@ class LogRecordStreamHandler(socketserver.StreamRequestHandler):
 class LogRecordSocketReceiver(socketserver.ThreadingTCPServer):
     """
     Simple TCP socket-based logging receiver.
+
+    Specialisation of the `socketserver.ThreadingTCPServer` class to handle
+    log records.
     """
 
     allow_reuse_address = True

--- a/docs/dagrunner.execute_graph.md
+++ b/docs/dagrunner.execute_graph.md
@@ -49,31 +49,31 @@ __init__(self, networkx_graph: str, <function plugin_executor>, scheduler: str =
 Execute a networkx graph using a chosen scheduler.
 
 Args:
-- networkx_graph (networkx.DiGraph, callable or str):
+- `networkx_graph` (networkx.DiGraph, callable or str):
   A networkx graph; dot path to a networkx graph or callable that returns 
-- one (str); tuple representing (edges, nodes) or callable object that
+  one; tuple representing (edges, nodes) or callable object that
   returns a networkx.
-- plugin_executor (callable):
+- `plugin_executor` (callable):
   A callable object that executes a plugin function or method with the provided
   arguments and keyword arguments.  By default, uses the `plugin_executor` function.
   Optional.
-- scheduler (str):
+- `scheduler` (str):
   Accepted values include "ray", "multiprocessing" and those recognised
   by dask: "threads", "processes" and "single-threaded" (useful for debugging).
   See https://docs.dask.org/en/latest/scheduling.html.  Optional.
-- num_workers (int):
+- `num_workers` (int):
   Number of processes or threads to use.  Optional.
-- dry_run (bool):
+- `dry_run` (bool):
   Print executed commands but don't actually run them.  Optional.
-- profiler_filepath (str):
+- `profiler_filepath` (str):
   Output html profile filepath if supported by the chosen scheduler.
   See https://docs.dask.org/en/latest/diagnostics-local.html
   Optional.
-- verbose (bool):
+- `verbose` (bool):
   Print executed commands.  Optional.
-- sqlite_filepath (str):
+- `sqlite_filepath` (str):
   Filepath to a SQLite database to store log records.  Optional.
-- **kwargs:
+- `**kwargs`:
   Optional global keyword arguments to apply to all applicable plugins.
 
 ### function: `visualise`

--- a/docs/dagrunner.utils.logger.md
+++ b/docs/dagrunner.utils.logger.md
@@ -5,9 +5,9 @@
 This module takes much from the Python logging cookbook:
 https://docs.python.org/3/howto/logging-cookbook.html#sending-and-receiving-logging-events-across-a-network
 
-- client_attach_socket_handler, a function that attaches a socket handler to the root
+- `client_attach_socket_handler`, a function that attaches a socket handler to the root
   logger.
-- ServerContext, a context manager that starts and manages the TCP server on its own
+- `ServerContext`, a context manager that starts and manages the TCP server on its own
   thread to receive log records.
 
 ## class: `LogRecordSocketReceiver`
@@ -22,29 +22,12 @@ LogRecordSocketReceiver(host='localhost', port=9020, <class LogRecordStreamHandl
 
 Simple TCP socket-based logging receiver.
 
-### function: `__enter__`
-
-[Source](../../../../../../project/ukmo/scitools/opt_scitools/conda/deployments/default-2023_11_28/lib/python3.10/socketserver.py#L383)
-
-#### Call Signature:
-
-```python
-__enter__(self)
-```
-
-### function: `__exit__`
-
-[Source](../../../../../../project/ukmo/scitools/opt_scitools/conda/deployments/default-2023_11_28/lib/python3.10/socketserver.py#L386)
-
-#### Call Signature:
-
-```python
-__exit__(self, *args)
-```
+Specialisation of the `socketserver.ThreadingTCPServer` class to handle
+log records.
 
 ### function: `__init__`
 
-[Source](../dagrunner/utils/logger.py#L105)
+[Source](../dagrunner/utils/logger.py#L108)
 
 #### Call Signature:
 
@@ -54,145 +37,9 @@ __init__(self, host='localhost', port=9020, <class LogRecordStreamHandler>, log_
 
 Constructor.  May be extended, do not override.
 
-### function: `close_request`
-
-[Source](../../../../../../project/ukmo/scitools/opt_scitools/conda/deployments/default-2023_11_28/lib/python3.10/socketserver.py#L511)
-
-#### Call Signature:
-
-```python
-close_request(self, request)
-```
-
-Called to clean up an individual request.
-
-### function: `fileno`
-
-[Source](../../../../../../project/ukmo/scitools/opt_scitools/conda/deployments/default-2023_11_28/lib/python3.10/socketserver.py#L485)
-
-#### Call Signature:
-
-```python
-fileno(self)
-```
-
-Return socket file number.
-
-Interface required by selector.
-
-### function: `finish_request`
-
-[Source](../../../../../../project/ukmo/scitools/opt_scitools/conda/deployments/default-2023_11_28/lib/python3.10/socketserver.py#L358)
-
-#### Call Signature:
-
-```python
-finish_request(self, request, client_address)
-```
-
-Finish one request by instantiating RequestHandlerClass.
-
-### function: `get_request`
-
-[Source](../../../../../../project/ukmo/scitools/opt_scitools/conda/deployments/default-2023_11_28/lib/python3.10/socketserver.py#L493)
-
-#### Call Signature:
-
-```python
-get_request(self)
-```
-
-Get the request and client address from the socket.
-
-May be overridden.
-
-### function: `handle_error`
-
-[Source](../../../../../../project/ukmo/scitools/opt_scitools/conda/deployments/default-2023_11_28/lib/python3.10/socketserver.py#L370)
-
-#### Call Signature:
-
-```python
-handle_error(self, request, client_address)
-```
-
-Handle an error gracefully.  May be overridden.
-
-The default is to print a traceback and continue.
-
-### function: `handle_request`
-
-[Source](../../../../../../project/ukmo/scitools/opt_scitools/conda/deployments/default-2023_11_28/lib/python3.10/socketserver.py#L273)
-
-#### Call Signature:
-
-```python
-handle_request(self)
-```
-
-Handle one request, possibly blocking.
-
-Respects self.timeout.
-
-### function: `handle_timeout`
-
-[Source](../../../../../../project/ukmo/scitools/opt_scitools/conda/deployments/default-2023_11_28/lib/python3.10/socketserver.py#L326)
-
-#### Call Signature:
-
-```python
-handle_timeout(self)
-```
-
-Called if no new request arrives within self.timeout.
-
-Overridden by ForkingMixIn.
-
-### function: `process_request`
-
-[Source](../../../../../../project/ukmo/scitools/opt_scitools/conda/deployments/default-2023_11_28/lib/python3.10/socketserver.py#L689)
-
-#### Call Signature:
-
-```python
-process_request(self, request, client_address)
-```
-
-Start a new thread to process the request.
-
-### function: `process_request_thread`
-
-[Source](../../../../../../project/ukmo/scitools/opt_scitools/conda/deployments/default-2023_11_28/lib/python3.10/socketserver.py#L676)
-
-#### Call Signature:
-
-```python
-process_request_thread(self, request, client_address)
-```
-
-Same as in BaseServer but as a thread.
-
-In addition, exception handling is done here.
-
-### function: `serve_forever`
-
-[Source](../../../../../../project/ukmo/scitools/opt_scitools/conda/deployments/default-2023_11_28/lib/python3.10/socketserver.py#L215)
-
-#### Call Signature:
-
-```python
-serve_forever(self, poll_interval=0.5)
-```
-
-Handle one request at a time until shutdown.
-
-Polls for shutdown every poll_interval seconds. Ignores
-self.timeout. If you need to do periodic tasks, do them in
-another thread.
-
 ### function: `serve_until_stopped`
 
-[Source](../dagrunner/utils/logger.py#L114)
+[Source](../dagrunner/utils/logger.py#L117)
 
 #### Call Signature:
 
@@ -200,110 +47,15 @@ another thread.
 serve_until_stopped(self, queue_handler=None)
 ```
 
-### function: `server_activate`
-
-[Source](../../../../../../project/ukmo/scitools/opt_scitools/conda/deployments/default-2023_11_28/lib/python3.10/socketserver.py#L469)
-
-#### Call Signature:
-
-```python
-server_activate(self)
-```
-
-Called by constructor to activate the server.
-
-May be overridden.
-
-### function: `server_bind`
-
-[Source](../../../../../../project/ukmo/scitools/opt_scitools/conda/deployments/default-2023_11_28/lib/python3.10/socketserver.py#L458)
-
-#### Call Signature:
-
-```python
-server_bind(self)
-```
-
-Called by constructor to bind the socket.
-
-May be overridden.
-
-### function: `server_close`
-
-[Source](../../../../../../project/ukmo/scitools/opt_scitools/conda/deployments/default-2023_11_28/lib/python3.10/socketserver.py#L699)
-
-#### Call Signature:
-
-```python
-server_close(self)
-```
-
-### function: `service_actions`
-
-[Source](../../../../../../project/ukmo/scitools/opt_scitools/conda/deployments/default-2023_11_28/lib/python3.10/socketserver.py#L254)
-
-#### Call Signature:
-
-```python
-service_actions(self)
-```
-
-Called by the serve_forever() loop.
-
-May be overridden by a subclass / Mixin to implement any code that
-needs to be run during the loop.
-
-### function: `shutdown`
-
-[Source](../../../../../../project/ukmo/scitools/opt_scitools/conda/deployments/default-2023_11_28/lib/python3.10/socketserver.py#L244)
-
-#### Call Signature:
-
-```python
-shutdown(self)
-```
-
-Stops the serve_forever loop.
-
-Blocks until the loop has finished. This must be called while
-serve_forever() is running in another thread, or it will
-deadlock.
-
-### function: `shutdown_request`
-
-[Source](../../../../../../project/ukmo/scitools/opt_scitools/conda/deployments/default-2023_11_28/lib/python3.10/socketserver.py#L501)
-
-#### Call Signature:
-
-```python
-shutdown_request(self, request)
-```
-
-Called to shutdown and close an individual request.
-
 ### function: `stop`
 
-[Source](../dagrunner/utils/logger.py#L127)
+[Source](../dagrunner/utils/logger.py#L130)
 
 #### Call Signature:
 
 ```python
 stop(self)
 ```
-
-### function: `verify_request`
-
-[Source](../../../../../../project/ukmo/scitools/opt_scitools/conda/deployments/default-2023_11_28/lib/python3.10/socketserver.py#L333)
-
-#### Call Signature:
-
-```python
-verify_request(self, request, client_address)
-```
-
-Verify the request.  May be overridden.
-
-Return True if we should proceed with this request.
 
 ## class: `LogRecordStreamHandler`
 
@@ -317,30 +69,8 @@ LogRecordStreamHandler(request, client_address, server)
 
 Handler for a streaming logging request.
 
-This basically logs the record using whatever logging policy is
-configured locally.
-
-### function: `__init__`
-
-[Source](../../../../../../project/ukmo/scitools/opt_scitools/conda/deployments/default-2023_11_28/lib/python3.10/socketserver.py#L741)
-
-#### Call Signature:
-
-```python
-__init__(self, request, client_address, server)
-```
-
-Initialize self.  See help(type(self)) for accurate signature.
-
-### function: `finish`
-
-[Source](../../../../../../project/ukmo/scitools/opt_scitools/conda/deployments/default-2023_11_28/lib/python3.10/socketserver.py#L803)
-
-#### Call Signature:
-
-```python
-finish(self)
-```
+Specialisation of the `socketserver.StreamRequestHandler` class to handle log
+records and customise logging events.
 
 ### function: `handle`
 
@@ -366,16 +96,6 @@ according to whatever policy is configured locally.
 handle_log_record(self, record)
 ```
 
-### function: `setup`
-
-[Source](../../../../../../project/ukmo/scitools/opt_scitools/conda/deployments/default-2023_11_28/lib/python3.10/socketserver.py#L790)
-
-#### Call Signature:
-
-```python
-setup(self)
-```
-
 ### function: `unpickle`
 
 [Source](../dagrunner/utils/logger.py#L80)
@@ -388,7 +108,7 @@ unpickle(self, data)
 
 ## class: `SQLiteQueueHandler`
 
-[Source](../dagrunner/utils/logger.py#L132)
+[Source](../dagrunner/utils/logger.py#L135)
 
 ### Call Signature:
 
@@ -398,7 +118,7 @@ SQLiteQueueHandler(sqfile='logs.sqlite')
 
 ### function: `__init__`
 
-[Source](../dagrunner/utils/logger.py#L133)
+[Source](../dagrunner/utils/logger.py#L136)
 
 #### Call Signature:
 
@@ -410,7 +130,7 @@ Initialize self.  See help(type(self)) for accurate signature.
 
 ### function: `close`
 
-[Source](../dagrunner/utils/logger.py#L169)
+[Source](../dagrunner/utils/logger.py#L172)
 
 #### Call Signature:
 
@@ -420,7 +140,7 @@ close(self)
 
 ### function: `write`
 
-[Source](../dagrunner/utils/logger.py#L157)
+[Source](../dagrunner/utils/logger.py#L160)
 
 #### Call Signature:
 
@@ -430,7 +150,7 @@ write(self, log_queue)
 
 ## class: `ServerContext`
 
-[Source](../dagrunner/utils/logger.py#L174)
+[Source](../dagrunner/utils/logger.py#L177)
 
 ### Call Signature:
 
@@ -450,7 +170,7 @@ Log format is:
 
 ### function: `__enter__`
 
-[Source](../dagrunner/utils/logger.py#L192)
+[Source](../dagrunner/utils/logger.py#L195)
 
 #### Call Signature:
 
@@ -460,7 +180,7 @@ __enter__(self)
 
 ### function: `__exit__`
 
-[Source](../dagrunner/utils/logger.py#L210)
+[Source](../dagrunner/utils/logger.py#L213)
 
 #### Call Signature:
 
@@ -470,7 +190,7 @@ __exit__(self, exc_type, exc_val, exc_tb)
 
 ### function: `__init__`
 
-[Source](../dagrunner/utils/logger.py#L187)
+[Source](../dagrunner/utils/logger.py#L190)
 
 #### Call Signature:
 
@@ -508,7 +228,7 @@ application:
 
 ## function: `main`
 
-[Source](../dagrunner/utils/logger.py#L215)
+[Source](../dagrunner/utils/logger.py#L218)
 
 ### Call Signature:
 

--- a/docs/dagrunner.utils.md
+++ b/docs/dagrunner.utils.md
@@ -2,13 +2,15 @@
 
 [Source](../dagrunner/utils/__init__.py#L0)
 
+see [module: _doc_styles](dagrunner.utils._doc_styles.md#module-dagrunnerutils_doc_styles)
+
 see [module: logger](dagrunner.utils.logger.md#module-dagrunnerutilslogger)
 
 see [module: visualisation](dagrunner.utils.visualisation.md#module-dagrunnerutilsvisualisation)
 
 ## class: `KeyValueAction`
 
-[Source](../dagrunner/utils/__init__.py#L126)
+[Source](../dagrunner/utils/__init__.py#L115)
 
 ### Call Signature:
 
@@ -67,7 +69,7 @@ Keyword Arguments:
 
 ### function: `__call__`
 
-[Source](../dagrunner/utils/__init__.py#L127)
+[Source](../dagrunner/utils/__init__.py#L116)
 
 #### Call Signature:
 
@@ -77,43 +79,9 @@ __call__(self, parser, namespace, values, option_string=None)
 
 Call self as a function.
 
-### function: `__init__`
-
-[Source](../../../../../../project/ukmo/scitools/opt_scitools/conda/deployments/default-2023_11_28/lib/python3.10/argparse.py#L827)
-
-#### Call Signature:
-
-```python
-__init__(self, option_strings, dest, nargs=None, const=None, default=None, type=None, choices=None, required=False, help=None, metavar=None)
-```
-
-Initialize self.  See help(type(self)) for accurate signature.
-
-### function: `__repr__`
-
-[Source](../../../../../../project/ukmo/scitools/opt_scitools/conda/deployments/default-2023_11_28/lib/python3.10/argparse.py#L116)
-
-#### Call Signature:
-
-```python
-__repr__(self)
-```
-
-Return repr(self).
-
-### function: `format_usage`
-
-[Source](../../../../../../project/ukmo/scitools/opt_scitools/conda/deployments/default-2023_11_28/lib/python3.10/argparse.py#L864)
-
-#### Call Signature:
-
-```python
-format_usage(self)
-```
-
 ## class: `ObjectAsStr`
 
-[Source](../dagrunner/utils/__init__.py#L10)
+[Source](../dagrunner/utils/__init__.py#L12)
 
 ### Call Signature:
 
@@ -125,7 +93,7 @@ Hide object under a string.
 
 ### function: `__hash__`
 
-[Source](../dagrunner/utils/__init__.py#L22)
+[Source](../dagrunner/utils/__init__.py#L24)
 
 #### Call Signature:
 
@@ -137,7 +105,7 @@ Return hash(self).
 
 ### function: `__new__`
 
-[Source](../dagrunner/utils/__init__.py#L13)
+[Source](../dagrunner/utils/__init__.py#L15)
 
 #### Call Signature:
 
@@ -149,7 +117,7 @@ Create and return a new object.  See help(type) for accurate signature.
 
 ### function: `obj_to_name`
 
-[Source](../dagrunner/utils/__init__.py#L26)
+[Source](../dagrunner/utils/__init__.py#L28)
 
 #### Call Signature:
 
@@ -159,7 +127,7 @@ obj_to_name(obj, cls)
 
 ## class: `TimeIt`
 
-[Source](../dagrunner/utils/__init__.py#L34)
+[Source](../dagrunner/utils/__init__.py#L36)
 
 ### Call Signature:
 
@@ -188,7 +156,7 @@ Example as a standalone timer:
 
 ### function: `__enter__`
 
-[Source](../dagrunner/utils/__init__.py#L62)
+[Source](../dagrunner/utils/__init__.py#L64)
 
 #### Call Signature:
 
@@ -198,7 +166,7 @@ __enter__(self)
 
 ### function: `__exit__`
 
-[Source](../dagrunner/utils/__init__.py#L66)
+[Source](../dagrunner/utils/__init__.py#L68)
 
 #### Call Signature:
 
@@ -208,7 +176,7 @@ __exit__(self, *args)
 
 ### function: `__init__`
 
-[Source](../dagrunner/utils/__init__.py#L56)
+[Source](../dagrunner/utils/__init__.py#L58)
 
 #### Call Signature:
 
@@ -220,7 +188,7 @@ Initialize self.  See help(type(self)) for accurate signature.
 
 ### function: `__str__`
 
-[Source](../dagrunner/utils/__init__.py#L91)
+[Source](../dagrunner/utils/__init__.py#L93)
 
 #### Call Signature:
 
@@ -232,7 +200,7 @@ Print elapsed time in seconds.
 
 ### function: `start`
 
-[Source](../dagrunner/utils/__init__.py#L72)
+[Source](../dagrunner/utils/__init__.py#L74)
 
 #### Call Signature:
 
@@ -242,7 +210,7 @@ start(self)
 
 ### function: `stop`
 
-[Source](../dagrunner/utils/__init__.py#L76)
+[Source](../dagrunner/utils/__init__.py#L78)
 
 #### Call Signature:
 
@@ -250,9 +218,19 @@ start(self)
 stop(self)
 ```
 
+## function: `docstring_parse`
+
+[Source](../dagrunner/utils/__init__.py#L98)
+
+### Call Signature:
+
+```python
+docstring_parse(obj)
+```
+
 ## function: `function_to_argparse`
 
-[Source](../dagrunner/utils/__init__.py#L138)
+[Source](../dagrunner/utils/__init__.py#L127)
 
 ### Call Signature:
 

--- a/docs/dagrunner_index.md
+++ b/docs/dagrunner_index.md
@@ -1,5 +1,5 @@
 # Index for 'dagrunner' reference documentation
-version: 0.0.1
+version: 0.0.1dev
 
   - [module: dagrunner](dagrunner.md#module-dagrunner)
     - [module: execute_graph](dagrunner.execute_graph.md#module-dagrunnerexecute_graph)
@@ -28,6 +28,7 @@ version: 0.0.1
       - [class: KeyValueAction](dagrunner.utils.md#class-keyvalueaction)
       - [class: ObjectAsStr](dagrunner.utils.md#class-objectasstr)
       - [class: TimeIt](dagrunner.utils.md#class-timeit)
+      - [function: docstring_parse](dagrunner.utils.md#function-docstring_parse)
       - [function: function_to_argparse](dagrunner.utils.md#function-function_to_argparse)
       - [module: logger](dagrunner.utils.logger.md#module-dagrunnerutilslogger)
         - [class: LogRecordSocketReceiver](dagrunner.utils.logger.md#class-logrecordsocketreceiver)

--- a/docs/gen_docs
+++ b/docs/gen_docs
@@ -154,12 +154,6 @@ def prioritised_get_members(module):
         if not no_include(obj, module.__name__):
             yield name, obj
 
-    # for member in inspect.getmembers(module, inspect.ismodule):
-    #     yield member
-    # for member in inspect.getmembers(module):
-    #     if not inspect.ismodule(member[1]):
-    #         yield member
-
 
 def generate_markdown_from_module(module_name, target_root):
     root_package = module_name.split('.')[0]
@@ -181,7 +175,7 @@ def generate_markdown_from_module(module_name, target_root):
 
         if inspect.isclass(obj):
             for cls_member_name, cls_member in inspect.getmembers(obj, inspect.ismethod and inspect.isfunction):
-                if is_private(cls_member_name):
+                if is_private(cls_member_name) or external_dependency(cls_member, root_package):
                     continue
                 markdown += gen_obj_markdown(3, cls_member, cls_member_name, target_root)
 


### PR DESCRIPTION
Function to generate argparse now supports markdown/google/numpy/rst.
`gen_docs` now correctly excludes parent class methods which are defined external to the package.
Updated documentation build.

## Issues

- https://github.com/MetOffice/improver_suite/issues/2079