### PR TITLE
TEST: Copyright pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,10 @@ repos:
       args: [ --fix ]
     # Run the formatter.
     - id: ruff-format
+- repo: local
+  hooks:
+    - id: copyright
+      name: Check copyright header
+      files: '\.py$'
+      language: system
+      entry: ./copyright_check

--- a/copyright_check
+++ b/copyright_check
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Call copyright_check with 1 or more filepath arguments to check.
+
+copyright_header="\
+# (C) Crown Copyright, Met Office. All rights reserved.\n\
+#\n\
+# This file is part of 'dagrunner' and is released under the BSD 3-Clause license.\n\
+# See LICENSE in the root of the repository for full licensing details.\
+"
+
+contains_copyright() {
+    grep -qi '# .*copyright' $1
+}
+
+
+defines_hash_bang() {
+    grep -q '^#!' $1
+}
+
+
+correct_copyright() {
+    python -c 'import sys; sys.exit(0 if "'"$1"'" in open("'"$2"'", "r").read() else 1)'
+}
+
+found_error=0
+for filepath in "$@"; do
+    if contains_copyright "${filepath}"; then
+        #echo "File '${filepath}' already contains Crown Copyright"
+        if correct_copyright "${copyright_header}" "${filepath}"; then
+            continue
+        else
+            echo "Incorrect Copyright header in '${filepath}'"
+            found_error=1
+        fi
+    elif [ -s "${filepath}" ]; then  # skip empty files
+        echo "Adding missing Copyright to '${filepath}'"
+        tmp_file="${filepath}.tmp"
+        rm -f ${tmp_file} 2&> /dev/null
+        touch ${tmp_file}
+        if defines_hash_bang "${filepath}"; then
+            head -n 1 ${filepath} > ${tmp_file}
+            echo -e ${copyright_header} >> ${tmp_file}
+            tail -n +2 ${filepath} >> ${tmp_file}
+        else
+            echo -e ${copyright_header} >> ${tmp_file}
+            cat ${filepath} >> ${tmp_file}
+        fi
+        mv ${tmp_file} ${filepath}
+        found_error=1
+    fi
+done
+
+exit ${found_error}

--- a/copyright_check
+++ b/copyright_check
@@ -1,5 +1,27 @@
 #!/bin/bash
-# Call copyright_check with 1 or more filepath arguments to check.
+
+show_help() {
+    echo "info: Check the copyright header in the specified files."
+    echo "    If the non-empty file does not contain the copyright header, it "
+    echo "    will be added. If a file looks like it does contain a copyright "
+    echo "    header, it will verified that it matches exactly."
+    echo "    Hash bangs are preserved."
+    echo ''
+    echo "usage: $0 FILEPATH..."
+    echo ''
+    echo 'positional arguments:'
+    echo '  FILEPATH...    The file(s) to check'
+    echo ""
+    echo "options:"
+    echo "  -h|--help     Show this help message and exit"
+    echo ""
+}
+
+if [[ " $@ " =~ " --help " || " $@ " =~ " -h " ]]; then
+    show_help
+    exit 0
+fi
+
 
 copyright_header="\
 # (C) Crown Copyright, Met Office. All rights reserved.\n\
@@ -22,6 +44,21 @@ correct_copyright() {
     python -c 'import sys; sys.exit(0 if "'"$1"'" in open("'"$2"'", "r").read() else 1)'
 }
 
+
+# Function to delete temporary files
+cleanup() {
+    for filepath in "$@"; do
+        tmp_file="${filepath}.tmp"
+        if [ -f "$tmp_file" ]; then
+            echo "Deleting temporary file: $tmp_file"
+            rm -f "$tmp_file" 2&> /dev/null
+        fi
+    done
+}
+
+# Trap the EXIT signal to call the cleanup function
+trap 'cleanup "$@"' EXIT
+
 found_error=0
 for filepath in "$@"; do
     if contains_copyright "${filepath}"; then
@@ -35,14 +72,12 @@ for filepath in "$@"; do
     elif [ -s "${filepath}" ]; then  # skip empty files
         echo "Adding missing Copyright to '${filepath}'"
         tmp_file="${filepath}.tmp"
-        rm -f ${tmp_file} 2&> /dev/null
-        touch ${tmp_file}
         if defines_hash_bang "${filepath}"; then
             head -n 1 ${filepath} > ${tmp_file}
             echo -e ${copyright_header} >> ${tmp_file}
             tail -n +2 ${filepath} >> ${tmp_file}
         else
-            echo -e ${copyright_header} >> ${tmp_file}
+            echo -e ${copyright_header} > ${tmp_file}
             cat ${filepath} >> ${tmp_file}
         fi
         mv ${tmp_file} ${filepath}

--- a/dagrunner/runner/schedulers/base.py
+++ b/dagrunner/runner/schedulers/base.py
@@ -1,3 +1,7 @@
+# (C) Crown Copyright, Met Office. All rights reserved.
+#
+# This file is part of 'dagrunner' and is released under the BSD 3-Clause license.
+# See LICENSE in the root of the repository for full licensing details.
 # # Abstract base class for schedulers
 # from typing import Protocol, Any
 

--- a/dagrunner/runner/schedulers/dask.py
+++ b/dagrunner/runner/schedulers/dask.py
@@ -1,3 +1,7 @@
+# (C) Crown Copyright, Met Office. All rights reserved.
+#
+# This file is part of 'dagrunner' and is released under the BSD 3-Clause license.
+# See LICENSE in the root of the repository for full licensing details.
 """
 Standardised UI for dask compatible schedulers (including 'dask on ray')
 

--- a/dagrunner/tests/utils/logging/test_integration.py
+++ b/dagrunner/tests/utils/logging/test_integration.py
@@ -1,3 +1,7 @@
+# (C) Crown Copyright, Met Office. All rights reserved.
+#
+# This file is part of 'dagrunner' and is released under the BSD 3-Clause license.
+# See LICENSE in the root of the repository for full licensing details.
 import sqlite3
 import subprocess
 import time

--- a/dagrunner/tests/utils/test_TimeIt.py
+++ b/dagrunner/tests/utils/test_TimeIt.py
@@ -1,3 +1,7 @@
+# (C) Crown Copyright, Met Office. All rights reserved.
+#
+# This file is part of 'dagrunner' and is released under the BSD 3-Clause license.
+# See LICENSE in the root of the repository for full licensing details.
 from time import sleep
 
 from dagrunner.utils import TimeIt

--- a/dagrunner/tests/utils/test_docstring_parse.py
+++ b/dagrunner/tests/utils/test_docstring_parse.py
@@ -1,3 +1,7 @@
+# (C) Crown Copyright, Met Office. All rights reserved.
+#
+# This file is part of 'dagrunner' and is released under the BSD 3-Clause license.
+# See LICENSE in the root of the repository for full licensing details.
 from dagrunner.utils import docstring_parse
 import pytest
 

--- a/dagrunner/utils/logger.py
+++ b/dagrunner/utils/logger.py
@@ -1,3 +1,7 @@
+# (C) Crown Copyright, Met Office. All rights reserved.
+#
+# This file is part of 'dagrunner' and is released under the BSD 3-Clause license.
+# See LICENSE in the root of the repository for full licensing details.
 """
 This module takes much from the Python logging cookbook:
 https://docs.python.org/3/howto/logging-cookbook.html#sending-and-receiving-logging-events-across-a-network

--- a/docs/dagrunner.runner.schedulers.dask.md
+++ b/docs/dagrunner.runner.schedulers.dask.md
@@ -15,7 +15,7 @@ See the following useful background reading:
 
 ## class: `DaskOnRay`
 
-[Source](../dagrunner/runner/schedulers/dask.py#L200)
+[Source](../dagrunner/runner/schedulers/dask.py#L204)
 
 ### Call Signature:
 
@@ -27,7 +27,7 @@ A class to run dask graphs using the 'dak-on-ray' scheduler.
 
 ### function: `__enter__`
 
-[Source](../dagrunner/runner/schedulers/dask.py#L208)
+[Source](../dagrunner/runner/schedulers/dask.py#L212)
 
 #### Call Signature:
 
@@ -37,7 +37,7 @@ __enter__(self)
 
 ### function: `__exit__`
 
-[Source](../dagrunner/runner/schedulers/dask.py#L211)
+[Source](../dagrunner/runner/schedulers/dask.py#L215)
 
 #### Call Signature:
 
@@ -47,7 +47,7 @@ __exit__(self, exc_type, exc_value, exc_traceback)
 
 ### function: `__init__`
 
-[Source](../dagrunner/runner/schedulers/dask.py#L203)
+[Source](../dagrunner/runner/schedulers/dask.py#L207)
 
 #### Call Signature:
 
@@ -59,7 +59,7 @@ Initialize self.  See help(type(self)) for accurate signature.
 
 ### function: `run`
 
-[Source](../dagrunner/runner/schedulers/dask.py#L216)
+[Source](../dagrunner/runner/schedulers/dask.py#L220)
 
 #### Call Signature:
 
@@ -80,7 +80,7 @@ Returns:
 
 ## class: `Distributed`
 
-[Source](../dagrunner/runner/schedulers/dask.py#L80)
+[Source](../dagrunner/runner/schedulers/dask.py#L84)
 
 ### Call Signature:
 
@@ -92,7 +92,7 @@ A class to run dask graphs on a distributed cluster.
 
 ### function: `__enter__`
 
-[Source](../dagrunner/runner/schedulers/dask.py#L89)
+[Source](../dagrunner/runner/schedulers/dask.py#L93)
 
 #### Call Signature:
 
@@ -104,7 +104,7 @@ Create a local cluster and connect a client to it.
 
 ### function: `__exit__`
 
-[Source](../dagrunner/runner/schedulers/dask.py#L100)
+[Source](../dagrunner/runner/schedulers/dask.py#L104)
 
 #### Call Signature:
 
@@ -114,7 +114,7 @@ __exit__(self)
 
 ### function: `__init__`
 
-[Source](../dagrunner/runner/schedulers/dask.py#L83)
+[Source](../dagrunner/runner/schedulers/dask.py#L87)
 
 #### Call Signature:
 
@@ -126,7 +126,7 @@ Initialize self.  See help(type(self)) for accurate signature.
 
 ### function: `run`
 
-[Source](../dagrunner/runner/schedulers/dask.py#L104)
+[Source](../dagrunner/runner/schedulers/dask.py#L108)
 
 #### Call Signature:
 
@@ -147,7 +147,7 @@ Returns:
 
 ## class: `SingleMachine`
 
-[Source](../dagrunner/runner/schedulers/dask.py#L129)
+[Source](../dagrunner/runner/schedulers/dask.py#L133)
 
 ### Call Signature:
 
@@ -159,7 +159,7 @@ A class to run dask graphs on a single machine.
 
 ### function: `__enter__`
 
-[Source](../dagrunner/runner/schedulers/dask.py#L141)
+[Source](../dagrunner/runner/schedulers/dask.py#L145)
 
 #### Call Signature:
 
@@ -169,7 +169,7 @@ __enter__(self)
 
 ### function: `__exit__`
 
-[Source](../dagrunner/runner/schedulers/dask.py#L196)
+[Source](../dagrunner/runner/schedulers/dask.py#L200)
 
 #### Call Signature:
 
@@ -179,7 +179,7 @@ __exit__(self, exc_type, exc_value, exc_traceback)
 
 ### function: `__init__`
 
-[Source](../dagrunner/runner/schedulers/dask.py#L132)
+[Source](../dagrunner/runner/schedulers/dask.py#L136)
 
 #### Call Signature:
 
@@ -191,7 +191,7 @@ Initialize self.  See help(type(self)) for accurate signature.
 
 ### function: `run`
 
-[Source](../dagrunner/runner/schedulers/dask.py#L144)
+[Source](../dagrunner/runner/schedulers/dask.py#L148)
 
 #### Call Signature:
 
@@ -212,7 +212,7 @@ Returns:
 
 ## function: `add_dummy_tasks`
 
-[Source](../dagrunner/runner/schedulers/dask.py#L34)
+[Source](../dagrunner/runner/schedulers/dask.py#L38)
 
 ### Call Signature:
 
@@ -242,7 +242,7 @@ TODO:
 
 ## function: `no_op`
 
-[Source](../dagrunner/runner/schedulers/dask.py#L26)
+[Source](../dagrunner/runner/schedulers/dask.py#L30)
 
 ### Call Signature:
 

--- a/docs/dagrunner.utils.logger.md
+++ b/docs/dagrunner.utils.logger.md
@@ -12,7 +12,7 @@ https://docs.python.org/3/howto/logging-cookbook.html#sending-and-receiving-logg
 
 ## class: `LogRecordSocketReceiver`
 
-[Source](../dagrunner/utils/logger.py#L101)
+[Source](../dagrunner/utils/logger.py#L105)
 
 ### Call Signature:
 
@@ -27,7 +27,7 @@ log records.
 
 ### function: `__init__`
 
-[Source](../dagrunner/utils/logger.py#L111)
+[Source](../dagrunner/utils/logger.py#L115)
 
 #### Call Signature:
 
@@ -39,7 +39,7 @@ Constructor.  May be extended, do not override.
 
 ### function: `serve_until_stopped`
 
-[Source](../dagrunner/utils/logger.py#L124)
+[Source](../dagrunner/utils/logger.py#L128)
 
 #### Call Signature:
 
@@ -49,7 +49,7 @@ serve_until_stopped(self, queue_handler=None)
 
 ### function: `stop`
 
-[Source](../dagrunner/utils/logger.py#L136)
+[Source](../dagrunner/utils/logger.py#L140)
 
 #### Call Signature:
 
@@ -59,7 +59,7 @@ stop(self)
 
 ## class: `LogRecordStreamHandler`
 
-[Source](../dagrunner/utils/logger.py#L52)
+[Source](../dagrunner/utils/logger.py#L56)
 
 ### Call Signature:
 
@@ -74,7 +74,7 @@ records and customise logging events.
 
 ### function: `handle`
 
-[Source](../dagrunner/utils/logger.py#L60)
+[Source](../dagrunner/utils/logger.py#L64)
 
 #### Call Signature:
 
@@ -88,7 +88,7 @@ according to whatever policy is configured locally.
 
 ### function: `handle_log_record`
 
-[Source](../dagrunner/utils/logger.py#L86)
+[Source](../dagrunner/utils/logger.py#L90)
 
 #### Call Signature:
 
@@ -98,7 +98,7 @@ handle_log_record(self, record)
 
 ### function: `unpickle`
 
-[Source](../dagrunner/utils/logger.py#L83)
+[Source](../dagrunner/utils/logger.py#L87)
 
 #### Call Signature:
 
@@ -108,7 +108,7 @@ unpickle(self, data)
 
 ## class: `SQLiteQueueHandler`
 
-[Source](../dagrunner/utils/logger.py#L141)
+[Source](../dagrunner/utils/logger.py#L145)
 
 ### Call Signature:
 
@@ -118,7 +118,7 @@ SQLiteQueueHandler(sqfile='logs.sqlite')
 
 ### function: `__init__`
 
-[Source](../dagrunner/utils/logger.py#L142)
+[Source](../dagrunner/utils/logger.py#L146)
 
 #### Call Signature:
 
@@ -130,7 +130,7 @@ Initialize self.  See help(type(self)) for accurate signature.
 
 ### function: `close`
 
-[Source](../dagrunner/utils/logger.py#L190)
+[Source](../dagrunner/utils/logger.py#L194)
 
 #### Call Signature:
 
@@ -140,7 +140,7 @@ close(self)
 
 ### function: `write`
 
-[Source](../dagrunner/utils/logger.py#L167)
+[Source](../dagrunner/utils/logger.py#L171)
 
 #### Call Signature:
 
@@ -150,7 +150,7 @@ write(self, log_queue)
 
 ## class: `ServerContext`
 
-[Source](../dagrunner/utils/logger.py#L195)
+[Source](../dagrunner/utils/logger.py#L199)
 
 ### Call Signature:
 
@@ -170,7 +170,7 @@ Log format is:
 
 ### function: `__enter__`
 
-[Source](../dagrunner/utils/logger.py#L214)
+[Source](../dagrunner/utils/logger.py#L218)
 
 #### Call Signature:
 
@@ -180,7 +180,7 @@ __enter__(self)
 
 ### function: `__exit__`
 
-[Source](../dagrunner/utils/logger.py#L236)
+[Source](../dagrunner/utils/logger.py#L240)
 
 #### Call Signature:
 
@@ -190,7 +190,7 @@ __exit__(self, exc_type, exc_val, exc_tb)
 
 ### function: `__init__`
 
-[Source](../dagrunner/utils/logger.py#L209)
+[Source](../dagrunner/utils/logger.py#L213)
 
 #### Call Signature:
 
@@ -202,7 +202,7 @@ Initialize self.  See help(type(self)) for accurate signature.
 
 ## function: `client_attach_socket_handler`
 
-[Source](../dagrunner/utils/logger.py#L24)
+[Source](../dagrunner/utils/logger.py#L28)
 
 ### Call Signature:
 
@@ -228,7 +228,7 @@ application:
 
 ## function: `main`
 
-[Source](../dagrunner/utils/logger.py#L241)
+[Source](../dagrunner/utils/logger.py#L245)
 
 ### Call Signature:
 


### PR DESCRIPTION
Added copyright pre-commit check.

Copyright check acts to check for the presence of and verify the validity of the copyright header of python files.  Additionally, the role of the script is to automatically add this copyright notice (thus eliminating the need to deal with copyright headers yourself).

- Verifies that **non-empty** python files contains some sort-of copyright header.
  - If copyright is present, checks that this copyright exactly matches the header we expect and fail if the copyright header doesn't match.
  - If copyright not present, then add it and fail.
    - Respects files including a hash bang (i.e. correctly auto adds copyright AFTER the hash bang line when present).

## Issues

- https://github.com/MetOffice/improver_suite/issues/2079
- https://github.com/MetOffice/improver_suite/issues/2253

## Note

Just to raise awareness as the first dagrunner PR under review - since this branch makes changes that impact the reference documentation, an auto reference documentation build commit will be pushed accordingly thanks to the dagrunner action [workflow](https://github.com/MetOffice/dagrunner/blob/07e3982d6161cd1ada351f79628333e69ddeaf0c/.github/workflows/tests.yml#L59-L79).

![image](https://github.com/MetOffice/dagrunner/assets/2071643/2920c38f-d88a-49fa-b9b7-c7a4c3a2823b)