### PR TITLE
ENH: Support passing parameters for plugin class initialisation

### DIFF
--- a/dagrunner/tests/execute_graph/test_integration.py
+++ b/dagrunner/tests/execute_graph/test_integration.py
@@ -29,8 +29,12 @@ class ProcessID(Plugin):
     This facilitates testing of the parallel execution of the graph.
     """
 
-    def __call__(self, *args, id=None, debug=False):
-        if debug:
+    def __init__(self, debug=False) -> None:
+        self._debug = debug
+        super().__init__()
+
+    def __call__(self, *args, id=None):
+        if self._debug:
             time.sleep(1)
         concat_arg_id = str(id)
         if args and args[0]:
@@ -79,7 +83,7 @@ def graph(tmp_path_factory):
         for nodenum in range(1, 6):
             node = vars()[f"node{nodenum}"]
             SETTINGS[node] = {
-                "call": tuple([ProcessID, {"id": nodenum, "debug": False}]),
+                "call": tuple([ProcessID, {"id": nodenum}]),
             }
 
         node_save = Node(step="save", leadtime=leadtime)
@@ -107,7 +111,8 @@ def test_execution(graph, scheduler):
     branch for recording the final state.  It is this that we verify to ensure that
     the graph has been executed correctly and respected dependencies.
     """
-    # when debug==True, ProcessID does a sleep.  This is useful for testing parallel execution.
+    # set debug to true to intriduce a 'sleep' to ProcessID.  Useful for verifying rough
+    # parallel execution performance.
     debug = False
     EDGES, SETTINGS, output_files = graph
     with patch("dagrunner.execute_graph.logger.ServerContext"):

--- a/dagrunner/tests/execute_graph/test_integration.py
+++ b/dagrunner/tests/execute_graph/test_integration.py
@@ -111,7 +111,7 @@ def test_execution(graph, scheduler):
     branch for recording the final state.  It is this that we verify to ensure that
     the graph has been executed correctly and respected dependencies.
     """
-    # set debug to true to intriduce a 'sleep' to ProcessID.  Useful for verifying rough
+    # set debug to true to introduce a 'sleep' to ProcessID.  Useful for verifying rough
     # parallel execution performance.
     debug = False
     EDGES, SETTINGS, output_files = graph

--- a/dagrunner/tests/execute_graph/test_plugin_executor.py
+++ b/dagrunner/tests/execute_graph/test_plugin_executor.py
@@ -1,0 +1,59 @@
+# (C) Crown Copyright, Met Office. All rights reserved.
+#
+# This file is part of 'dagrunner' and is released under the BSD 3-Clause license.
+# See LICENSE in the root of the repository for full licensing details.
+from unittest import mock
+
+from dagrunner.execute_graph import plugin_executor
+
+
+class DummyPlugin:
+    def __init__(self, iarg1, ikwarg1=None) -> None:
+        self._iarg1 = iarg1
+        self._ikwarg1 = ikwarg1
+
+    def __call__(self, *args, kwarg1=None, **kwargs):
+        return f"iarg1={self._iarg1}; ikwarg1={self._ikwarg1}; args={args}; kwarg1={kwarg1}; kwargs={kwargs}"
+
+
+def test_pass_class_arg_kwargs():
+    """Test passing named parameters to plugin class and __call__ method."""
+    args = (mock.sentinel.arg1, mock.sentinel.arg2)
+    call = tuple(
+        [
+            DummyPlugin,
+            {"iarg1": mock.sentinel.iarg1, "ikwarg1": mock.sentinel.ikwarg1},
+            {"kwarg1": mock.sentinel.kwarg1},
+        ]
+    )
+    res = plugin_executor(*args, call=call)
+    assert (
+        res
+        == "iarg1=sentinel.iarg1; ikwarg1=sentinel.ikwarg1; args=(sentinel.arg1, sentinel.arg2); kwarg1=sentinel.kwarg1; kwargs={}"
+    )
+
+
+def test_pass_common_args():
+    """Passing 'common args', some relevant to class init and some to call method."""
+    args = (mock.sentinel.arg1, mock.sentinel.arg2)
+    common_kwargs = {
+        "ikwarg1": mock.sentinel.ikwarg1,
+        "kwarg1": mock.sentinel.kwarg1,
+        "iarg1": mock.sentinel.iarg1,
+    }
+
+    # call without common args (iarg1 is positional so non-optional)
+    call = tuple([DummyPlugin, {"iarg1": mock.sentinel.iarg1}, {}])
+    res = plugin_executor(*args, call=call)
+    assert (
+        res
+        == "iarg1=sentinel.iarg1; ikwarg1=None; args=(sentinel.arg1, sentinel.arg2); kwarg1=None; kwargs={}"
+    )
+
+    # call with common args
+    call = tuple([DummyPlugin, {}, {}])
+    res = plugin_executor(*args, call=call, common_kwargs=common_kwargs)
+    assert (
+        res
+        == "iarg1=sentinel.iarg1; ikwarg1=sentinel.ikwarg1; args=(sentinel.arg1, sentinel.arg2); kwarg1=sentinel.kwarg1; kwargs={}"
+    )

--- a/docs/dagrunner.execute_graph.md
+++ b/docs/dagrunner.execute_graph.md
@@ -14,7 +14,7 @@ see [function: dagrunner.utils.visualisation.visualise_graph](dagrunner.utils.vi
 
 ## class: `ExecuteGraph`
 
-[Source](../dagrunner/execute_graph.py#L170)
+[Source](../dagrunner/execute_graph.py#L197)
 
 ### Call Signature:
 
@@ -24,7 +24,7 @@ ExecuteGraph(networkx_graph: str, <function plugin_executor>, scheduler: str = '
 
 ### function: `__call__`
 
-[Source](../dagrunner/execute_graph.py#L264)
+[Source](../dagrunner/execute_graph.py#L291)
 
 #### Call Signature:
 
@@ -36,7 +36,7 @@ Call self as a function.
 
 ### function: `__init__`
 
-[Source](../dagrunner/execute_graph.py#L171)
+[Source](../dagrunner/execute_graph.py#L198)
 
 #### Call Signature:
 
@@ -76,7 +76,7 @@ Args:
 
 ### function: `visualise`
 
-[Source](../dagrunner/execute_graph.py#L261)
+[Source](../dagrunner/execute_graph.py#L288)
 
 #### Call Signature:
 
@@ -99,7 +99,7 @@ subsequent tasks.
 
 ## function: `main`
 
-[Source](../dagrunner/execute_graph.py#L277)
+[Source](../dagrunner/execute_graph.py#L304)
 
 ### Call Signature:
 
@@ -112,7 +112,7 @@ Parses command line arguments and executes the graph using the ExecuteGraph clas
 
 ## function: `plugin_executor`
 
-[Source](../dagrunner/execute_graph.py#L41)
+[Source](../dagrunner/execute_graph.py#L50)
 
 ### Call Signature:
 
@@ -124,12 +124,14 @@ Executes a plugin function or method with the provided arguments and keyword arg
 
 Args:
 - `*args`: Positional arguments to be passed to the plugin function or method.
-- `call`: A tuple containing the callable object or python dot path to one, and its keyword arguments.
+- `call`: A tuple containing the callable object or python dot path to one, keyword arguments
+  to instantiate this class (optional and where this callable is a class) and finally the keyword
+  arguments to be passed to this callable.
 - `verbose`: A boolean indicating whether to print verbose output.
 - `dry_run`: A boolean indicating whether to perform a dry run without executing the plugin.
 - `common_kwargs`: A dictionary of optional keyword arguments to apply to all applicable plugins.
-  That is, being passed to the plugin call if such keywords are expected from the plugin.
-  This is a useful alternative to global or environment variable usage.
+  That is, being passed to the plugin initialisation and or call if such keywords are expected
+  from the plugin.  This is a useful alternative to global or environment variable usage.
 - `**node_properties`: Node properties.  These will be passed to 'node-aware' plugins.
 
 Returns:


### PR DESCRIPTION
From the work in https://github.com/metoppv/improver/issues/1998, it has been made clear that some plugin classes are intended to be instantiated with parameters.  To that end, we need to ensure that the default plugin executor supports passing such parameters to the plugin class initialisation.

This change achieves this by 'call' optionally supporting a tuple of 2 or 3 in length.
_Illustrated_ as follows:

```python
try:
    callable_obj, callable_kwargs_init, callable_kwargs = call
except ValueError:
    callable_obj, callable_kwargs = call
    callable_kwargs_init = {}
```

## Issues

- Closes https://github.com/MetOffice/pp_demo_workflow/issues/46
- https://github.com/MetOffice/improver_suite/issues/2253