### PR TITLE
ENH: Passing arguments to graph callable

### DIFF
--- a/dagrunner/tests/utils/test_function_to_parse.py
+++ b/dagrunner/tests/utils/test_function_to_parse.py
@@ -1,0 +1,164 @@
+# (C) Crown Copyright, Met Office. All rights reserved.
+#
+# This file is part of 'dagrunner' and is released under the BSD 3-Clause license.
+# See LICENSE in the root of the repository for full licensing details.
+from io import StringIO
+import os
+import sys
+
+from dagrunner.utils import function_to_argparse
+
+
+CALLING_MOD = os.path.basename(sys.argv[0])
+
+
+def get_parser_help_string(parser):
+    buffer = StringIO()
+    parser.print_help(file=buffer)
+    return buffer.getvalue()
+
+
+def basic_args_kwargs_optional(arg1: int, arg2: str = None, arg3: bool = False):
+    """
+    Summary line.
+
+    Extended description of function.
+
+    Args:
+    - `arg1`: Description of arg1
+      further description.
+    - `arg2`: Description of arg2.
+    - `arg3`: Description of arg3.
+      Optional.
+
+    Returns:
+    - bool: Description of return value
+
+    """
+    return True
+
+
+def test_basic_args_kwargs_optional():
+    """Check function with positional and keyword arguments, one explicitly optional."""
+    parser = function_to_argparse(basic_args_kwargs_optional)
+    help_str = get_parser_help_string(parser)
+    tar = f"""usage: {CALLING_MOD} [-h] --arg2 ARG2 [--arg3] arg1
+
+Summary line.
+
+Extended description of function.
+
+positional arguments:
+  arg1         Description of arg1 further description.
+
+options:
+  -h, --help   show this help message and exit
+  --arg2 ARG2  Description of arg2.
+  --arg3       Description of arg3. Optional.
+"""
+    assert help_str == tar
+
+    args = parser.parse_args(["3", "--arg2", "arg2", "--arg3"])
+    assert args.arg1 == 3
+    assert args.arg2 == "arg2"
+    assert args.arg3 is True
+
+
+def kwargs_param_expand(**kwargs):
+    """
+    Summary line.
+
+    Extended description of function.
+
+    Args:
+    - `**kwargs`:
+        Optional global keyword arguments to apply to all applicable plugins.
+
+    Returns:
+    - bool: Description of return value
+
+    """
+    return True
+
+
+def test_kwargs_param_expand():
+    """Check function with **kwargs supported."""
+    parser = function_to_argparse(kwargs_param_expand)
+    help_str = get_parser_help_string(parser)
+    tar = f"""usage: {CALLING_MOD} [-h] [--kwargs key value]
+
+Summary line.
+
+Extended description of function.
+
+options:
+  -h, --help          show this help message and exit
+  --kwargs key value  Optional global keyword arguments to apply to all
+                      applicable plugins. Key-value pair argument.
+"""
+    assert help_str == tar
+
+    args = parser.parse_args(["--kwargs", "key1", "val1", "--kwargs", "key2", "val2"])
+    assert "kwargs" in args
+    assert args.kwargs == {"key1": "val1", "key2": "val2"}
+
+
+def dict_param(dkwarg1: dict, dkwarg2: dict = None):
+    # def dict_param(dkwarg: dict=None):
+    """
+    Summary line.
+
+    Extended description of function.
+
+    Args:
+    - `dkwarg1`: Description of kwarg1.  Optional.
+    - `dkwarg2`: Description of kwarg2.
+
+    Returns:
+    - bool: Description of return value
+
+    """
+    return True
+
+
+def test_dict_param():
+    """Test function with dict arg and kwarg"""
+    parser = function_to_argparse(dict_param)
+    help_str = get_parser_help_string(parser)
+    tar = f"""usage: {CALLING_MOD} [-h] [--dkwarg1 key value] --dkwarg2 key value
+
+Summary line.
+
+Extended description of function.
+
+options:
+  -h, --help           show this help message and exit
+  --dkwarg1 key value  Description of kwarg1. Optional. Key-value pair
+                       argument.
+  --dkwarg2 key value  Description of kwarg2. Key-value pair argument.
+"""
+    assert help_str == tar
+    args = parser.parse_args(
+        [
+            "--dkwarg1",
+            "dkwarg1_key1",
+            "dkwarg1_val1",
+            "--dkwarg1",
+            "dkwarg1_key2",
+            "dkwarg1_val2",
+            "--dkwarg2",
+            "dkwarg2_key1",
+            "dkwarg2_val1",
+            "--dkwarg2",
+            "dkwarg2_key2",
+            "dkwarg2_val2",
+        ]
+    )
+    assert args.dkwarg1 == {
+        "dkwarg1_key1": "dkwarg1_val1",
+        "dkwarg1_key2": "dkwarg1_val2",
+    }
+    assert args.dkwarg2 == {
+        "dkwarg2_key1": "dkwarg2_val1",
+        "dkwarg2_key2": "dkwarg2_val2",
+    }

--- a/dagrunner/utils/__init__.py
+++ b/dagrunner/utils/__init__.py
@@ -178,17 +178,20 @@ def function_to_argparse(func, parser=None, exclude=None):
             arg_num = "*" if arg_optional else "+"
             arg_kwargs.update(dict(nargs=arg_num))
             arg_kwargs["type"] = str
-        elif param.kind == inspect.Parameter.VAR_KEYWORD:
+        elif param.kind == inspect.Parameter.VAR_KEYWORD or arg_type is dict:
             arg_kwargs.pop("type")
             arg_kwargs["nargs"] = 2
             arg_kwargs["action"] = KeyValueAction
             arg_kwargs["metavar"] = ("key", "value")
             arg_kwargs["help"] += "\n Key-value pair argument."
-            arg_optional = True
+            arg_optional = (
+                True if param.kind == inspect.Parameter.VAR_KEYWORD else arg_optional
+            )
 
         if (
             param.default is not param.empty
             or param.kind == inspect.Parameter.VAR_KEYWORD
+            or arg_type is dict
         ):
             # is a keywarg
             arg_kwargs["dest"] = name

--- a/docs/dagrunner.execute_graph.md
+++ b/docs/dagrunner.execute_graph.md
@@ -14,17 +14,17 @@ see [function: dagrunner.utils.visualisation.visualise_graph](dagrunner.utils.vi
 
 ## class: `ExecuteGraph`
 
-[Source](../dagrunner/execute_graph.py#L197)
+[Source](../dagrunner/execute_graph.py#L200)
 
 ### Call Signature:
 
 ```python
-ExecuteGraph(networkx_graph: str, <function plugin_executor>, scheduler: str = 'processes', num_workers: int = 1, profiler_filepath: str = None, dry_run: bool = False, verbose: bool = False, sqlite_filepath: str = None, **kwargs)
+ExecuteGraph(networkx_graph: str, networkx_graph_kwargs: dict = None, <function plugin_executor>, scheduler: str = 'processes', num_workers: int = 1, profiler_filepath: str = None, dry_run: bool = False, verbose: bool = False, sqlite_filepath: str = None, **kwargs)
 ```
 
 ### function: `__call__`
 
-[Source](../dagrunner/execute_graph.py#L291)
+[Source](../dagrunner/execute_graph.py#L298)
 
 #### Call Signature:
 
@@ -36,12 +36,12 @@ Call self as a function.
 
 ### function: `__init__`
 
-[Source](../dagrunner/execute_graph.py#L198)
+[Source](../dagrunner/execute_graph.py#L201)
 
 #### Call Signature:
 
 ```python
-__init__(self, networkx_graph: str, <function plugin_executor>, scheduler: str = 'processes', num_workers: int = 1, profiler_filepath: str = None, dry_run: bool = False, verbose: bool = False, sqlite_filepath: str = None, **kwargs)
+__init__(self, networkx_graph: str, networkx_graph_kwargs: dict = None, <function plugin_executor>, scheduler: str = 'processes', num_workers: int = 1, profiler_filepath: str = None, dry_run: bool = False, verbose: bool = False, sqlite_filepath: str = None, **kwargs)
 ```
 
 Execute a networkx graph using a chosen scheduler.
@@ -51,6 +51,8 @@ Args:
   A networkx graph; dot path to a networkx graph or callable that returns
   one; tuple representing (edges, nodes) or callable object that
   returns a networkx.
+- `networkx_graph_kwargs` (dict):
+  Keyword arguments to pass to the networkx graph callable.  Optional.
 - `plugin_executor` (callable):
   A callable object that executes a plugin function or method with the provided
   arguments and keyword arguments.  By default, uses the `plugin_executor` function.
@@ -76,7 +78,7 @@ Args:
 
 ### function: `visualise`
 
-[Source](../dagrunner/execute_graph.py#L288)
+[Source](../dagrunner/execute_graph.py#L295)
 
 #### Call Signature:
 
@@ -99,7 +101,7 @@ subsequent tasks.
 
 ## function: `main`
 
-[Source](../dagrunner/execute_graph.py#L304)
+[Source](../dagrunner/execute_graph.py#L311)
 
 ### Call Signature:
 


### PR DESCRIPTION
Support passing parameters to the science callable that returns a graph.  This ultimately enables science graphs to have controllable behaviour.  Obvious examples include graph filtering.

![image](https://github.com/MetOffice/dagrunner/assets/2071643/28f1b9d3-a6b9-4445-aaa2-dea7d895f878)

So, this means supporting passing key, value pairs via the commandline which are passed to the science teams graph returning callable.

Example call:

```
execute_graph.py graph_config.graphs.ukvx --networkx-graph-kwargs file_filter_path dot-module-path
```
One can pass arbitrary arguments this way too:
```
... --networkx-graph-kwargs key1 val1 --networkx-graph-kwargs key2 val2 ...
```

## Issues

- https://github.com/MetOffice/improver_suite/issues/2253