### PR TITLE
Changes required to facilitate running of pp_demo_suite using head of dagrunner

### DIFF
--- a/dagrunner/execute_graph.py
+++ b/dagrunner/execute_graph.py
@@ -124,9 +124,9 @@ def plugin_executor(
         callable_obj = callable_obj(**callable_kwargs_init)
         call_msg = f"(**{callable_kwargs_init})"
 
-    callable_kwargs = callable_kwargs | _get_common_args_matching_signature(
-        callable_obj, common_kwargs
-    )
+    callable_kwargs = callable_kwargs | {
+        key: value for key, value in common_kwargs.items() if key in callable_kwargs
+    }  # based on overriding arguments
 
     msg = f"{obj_name}{call_msg}(*{args}, **{callable_kwargs})"
     if verbose:

--- a/dagrunner/tests/execute_graph/test_plugin_executor.py
+++ b/dagrunner/tests/execute_graph/test_plugin_executor.py
@@ -57,3 +57,37 @@ def test_pass_common_args():
         res
         == "iarg1=sentinel.iarg1; ikwarg1=sentinel.ikwarg1; args=(sentinel.arg1, sentinel.arg2); kwarg1=sentinel.kwarg1; kwargs={}"
     )
+
+
+class DummyPlugin2:
+    """Plugin that is reliant on data not explicitly defined in its UI."""
+
+    def __call__(self, *args, **kwargs):
+        return f"args={args}; kwargs={kwargs}"
+
+
+def test_pass_common_args_via_override():
+    """
+    Passing 'common args' to a plugin that doesn't have such arguments
+    defined in its signature.  Instead, filter out those that aren't
+    specified in the graph.
+    """
+    common_kwargs = {
+        "kwarg1": mock.sentinel.kwarg1,
+        "kwarg2": mock.sentinel.kwarg2,
+        "kwarg3": mock.sentinel.kwarg3,
+    }
+    args = []
+    call = tuple(
+        [
+            DummyPlugin2,
+            {
+                "kwarg1": mock.sentinel.kwarg1,
+                "kwarg2": mock.sentinel.kwarg2,
+            },
+        ]
+    )
+    res = plugin_executor(*args, call=call, common_kwargs=common_kwargs)
+    assert (
+        res == "args=(); kwargs={'kwarg1': sentinel.kwarg1, 'kwarg2': sentinel.kwarg2}"
+    )


### PR DESCRIPTION
Reverted change from #40 involving common args handling and filled in gap in testing to ensure we continue to support reliant behaviour.

Working `pp_demo_workflow` when using this dagrunner dev branch:
http://fcm1/cylc-review/taskjobs/cpelley?&suite=demo_workflow_dagrunner_head&no_fuzzy_time=0&tasks=execute_basic_model

Best explained from looking at the new testcase:

https://github.com/MetOffice/dagrunner/blob/82788418db7a385af1ba7ed8b57d11e0c7b599f8/dagrunner/tests/execute_graph/test_plugin_executor.py#L71-L73

## Issues

- https://github.com/MetOffice/improver_suite/issues/2253