### PR TITLE
Extended ruff config + CI reference fix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,12 +41,14 @@ jobs:
           pip uninstall dagrunner -y
 
       # TESTS (inc. test coverage)
+
       # excluded logging as per https://github.com/MetOffice/dagrunner/issues/39
       - name: Run pytest + coverage report gen
         run: pytest --cov=dagrunner --cov-report=term --cov-report=html --ignore=dagrunner/tests/utils/logging/test_integration.py | tee coverage_output.txt; test ${PIPESTATUS[0]} -eq 0
 
 
       # TESTS (main branch)
+
       - name: Cache ref branch coverage report
         id: cache-ref-coverage
         uses: actions/cache@v4
@@ -61,13 +63,15 @@ jobs:
           path: ref
           ref: ${{ github.base_ref }}
 
+      # excluded logging as per https://github.com/MetOffice/dagrunner/issues/39
       - name: Run tests with coverage for ref branch
         if: steps.cache-ref-coverage.outputs.cache-hit != 'true'
         run: |
           cd ref
-          pytest --cov=dagrunner --cov-report=term | tee coverage_output.txt
+          pytest --cov=dagrunner --cov-report=term --cov-report=html --ignore=dagrunner/tests/utils/logging/test_integration.py | tee coverage_output.txt; test ${PIPESTATUS[0]} -eq 0
 
       # TESTS (compare coverage)
+
       - name: Compare coverage
         id: comp-coverage
         run: |
@@ -139,6 +143,9 @@ jobs:
           echo "changed=$(git diff --quiet --exit-code || echo true)" | tee -a $GITHUB_OUTPUT
 
       # https://github.com/orgs/community/discussions/26560#discussioncomment-3531273
+      # This must be our very final step to ensure that it runs only on condition of
+      # success of all previous steps.  A pushed commit will not trigger the re-running
+      # of this workflow.
       - name: Commit and push documentation changes
         if: steps.check-docs.outputs.changed == 'true'
         run: |

--- a/dagrunner/__init__.py
+++ b/dagrunner/__init__.py
@@ -2,7 +2,7 @@
 #
 # This file is part of 'dagrunner' and is released under the BSD 3-Clause license.
 # See LICENSE in the root of the repository for full licensing details.
-from .plugin_framework import Plugin, Shell, Input, DataPolling, NodeAwarePlugin
+from .plugin_framework import DataPolling, Input, NodeAwarePlugin, Plugin, Shell
 
 __all__ = ["Plugin", "Shell", "Input", "DataPolling", "NodeAwarePlugin"]
 

--- a/dagrunner/plugin_framework.py
+++ b/dagrunner/plugin_framework.py
@@ -2,13 +2,13 @@
 #
 # This file is part of 'dagrunner' and is released under the BSD 3-Clause license.
 # See LICENSE in the root of the repository for full licensing details.
-from abc import ABC, abstractmethod
 import json
 import os
-from glob import glob
 import string
 import subprocess
 import time
+from abc import ABC, abstractmethod
+from glob import glob
 
 
 class Plugin(ABC):
@@ -72,12 +72,12 @@ class DataPolling(Plugin):
         Args:
         - *args: Variable length argument list of file patterns to be checked.
         - timeout (int): Timeout in seconds (default is 120 seconds).
-        - polling (int): Time interval in seconds between each poll (default is 1 second).
+        - polling (int): Time interval in seconds between each poll (default is 1
+          second).
         - file_count (int): Expected number of files to be found (default is None).
             If specified, the total number of files found can be greater than the
             number of arguments.  Each argument is expected to return a minimum of
             1 match each in either case.
-
 
         Returns:
         - None
@@ -102,7 +102,8 @@ class DataPolling(Plugin):
                 indx += 1
             elif verbose:
                 print(
-                    f"polling for '{fpattern}', time taken: {time_taken}s of limit {timeout}s"
+                    f"polling for '{fpattern}', time taken: {time_taken}s of limit "
+                    f"{timeout}s"
                 )
                 time.sleep(polling)
                 time_taken += polling
@@ -119,8 +120,9 @@ class Input(NodeAwarePlugin):
         """
         Given a filepath, expand it and return this string
 
-        Expand the provided filepath using the keyword arguments and environment variables.
-        Note that this plugin is 'node aware' since it is derived from the `NodeAwarePlugin`.
+        Expand the provided filepath using the keyword arguments and environment
+        variables.  Note that this plugin is 'node aware' since it is derived from the
+        `NodeAwarePlugin`.
 
         Args:
         - *args: Positional arguments are not accepted.

--- a/dagrunner/runner/schedulers/__init__.py
+++ b/dagrunner/runner/schedulers/__init__.py
@@ -16,8 +16,8 @@ name-scheduler lookup:
 """
 
 from functools import partial
-from . import asyncmp
-from . import dask
+
+from . import asyncmp, dask
 
 # Schedulers that can be used with the runner, a name-lookup.
 SCHEDULERS = {

--- a/dagrunner/runner/schedulers/asyncmp.py
+++ b/dagrunner/runner/schedulers/asyncmp.py
@@ -2,10 +2,10 @@
 #
 # This file is part of 'dagrunner' and is released under the BSD 3-Clause license.
 # See LICENSE in the root of the repository for full licensing details.
-from multiprocessing import Pool
-from typing import Iterable, Any
-from time import sleep
 import warnings
+from multiprocessing import Pool
+from time import sleep
+from typing import Any, Iterable
 
 from dask.core import get_deps
 
@@ -81,7 +81,7 @@ class AsyncMP:
             warnings.warn("profiler output not supported for multiprocessing scheduler")
 
         pred_deps, succ_deps = get_deps(graph)
-        pass_data_in_memory = True  # pass data between processes in memory (flag provided to make testing easier)
+        pass_data_in_memory = True  # pass data between processes in memory
         data_map = {}  # map between target and result
 
         # Submit initial nodes
@@ -117,8 +117,8 @@ class AsyncMP:
                     node_queue.extend(succ_deps[target])  # nodes we want to run next
 
                     if pass_data_in_memory:
-                        # manage data being held
-                        # throw away data no longer needed - when all successors are completed
+                        # manage data being held - throw away data no longer needed,
+                        # when all successors are completed
                         data_map[target] = async_res.get()  # store result
                         for d_tgt in list(data_map.keys()):
                             succ_deps[d_tgt] = [

--- a/dagrunner/tests/execute_graph/test_integration.py
+++ b/dagrunner/tests/execute_graph/test_integration.py
@@ -2,16 +2,15 @@
 #
 # This file is part of 'dagrunner' and is released under the BSD 3-Clause license.
 # See LICENSE in the root of the repository for full licensing details.
-from dataclasses import dataclass
 import json
 import time
+from dataclasses import dataclass
 from unittest.mock import patch
 
 import pytest
 
-from dagrunner.plugin_framework import Plugin, SaveJson
 from dagrunner.execute_graph import ExecuteGraph
-
+from dagrunner.plugin_framework import Plugin, SaveJson
 
 HOUR = 3600
 MINUTE = 60

--- a/dagrunner/tests/execute_graph/test_plugin_executor.py
+++ b/dagrunner/tests/execute_graph/test_plugin_executor.py
@@ -13,7 +13,10 @@ class DummyPlugin:
         self._ikwarg1 = ikwarg1
 
     def __call__(self, *args, kwarg1=None, **kwargs):
-        return f"iarg1={self._iarg1}; ikwarg1={self._ikwarg1}; args={args}; kwarg1={kwarg1}; kwargs={kwargs}"
+        return (
+            f"iarg1={self._iarg1}; ikwarg1={self._ikwarg1}; args={args}; "
+            f"kwarg1={kwarg1}; kwargs={kwargs}"
+        )
 
 
 def test_pass_class_arg_kwargs():
@@ -27,9 +30,10 @@ def test_pass_class_arg_kwargs():
         ]
     )
     res = plugin_executor(*args, call=call)
-    assert (
-        res
-        == "iarg1=sentinel.iarg1; ikwarg1=sentinel.ikwarg1; args=(sentinel.arg1, sentinel.arg2); kwarg1=sentinel.kwarg1; kwargs={}"
+    assert res == (
+        "iarg1=sentinel.iarg1; ikwarg1=sentinel.ikwarg1; "
+        "args=(sentinel.arg1, sentinel.arg2); kwarg1=sentinel.kwarg1; "
+        "kwargs={}"
     )
 
 
@@ -45,17 +49,18 @@ def test_pass_common_args():
     # call without common args (iarg1 is positional so non-optional)
     call = tuple([DummyPlugin, {"iarg1": mock.sentinel.iarg1}, {}])
     res = plugin_executor(*args, call=call)
-    assert (
-        res
-        == "iarg1=sentinel.iarg1; ikwarg1=None; args=(sentinel.arg1, sentinel.arg2); kwarg1=None; kwargs={}"
+    assert res == (
+        "iarg1=sentinel.iarg1; ikwarg1=None; args=(sentinel.arg1, "
+        "sentinel.arg2); kwarg1=None; kwargs={}"
     )
 
     # call with common args
     call = tuple([DummyPlugin, {}, {}])
     res = plugin_executor(*args, call=call, common_kwargs=common_kwargs)
-    assert (
-        res
-        == "iarg1=sentinel.iarg1; ikwarg1=sentinel.ikwarg1; args=(sentinel.arg1, sentinel.arg2); kwarg1=sentinel.kwarg1; kwargs={}"
+    assert res == (
+        "iarg1=sentinel.iarg1; ikwarg1=sentinel.ikwarg1; "
+        "args=(sentinel.arg1, sentinel.arg2); kwarg1=sentinel.kwarg1; "
+        "kwargs={}"
     )
 
 

--- a/dagrunner/tests/utils/logging/test_integration.py
+++ b/dagrunner/tests/utils/logging/test_integration.py
@@ -2,11 +2,12 @@
 #
 # This file is part of 'dagrunner' and is released under the BSD 3-Clause license.
 # See LICENSE in the root of the repository for full licensing details.
+import logging
+import os
 import sqlite3
 import subprocess
 import time
-import logging
-import os
+
 import pytest
 
 from dagrunner.utils.logger import ServerContext
@@ -70,8 +71,10 @@ def test_sqlitedb(test_inputs, sqlite_filepath, caplog):
     assert count > 0, "At least one log record should be stored in the database"
 
     # Verify database records
-    # (record.created, record.name, record.levelname, record.getMessage(), record.hostname, record.process, record.thread)
-    # Verify against expected values and ensure dynamic values are of the expected type.
+    # (record.created, record.name, record.levelname, record.getMessage(),
+    #  record.hostname, record.process, record.thread)
+    # Verify against expected values and ensure dynamic values are of the expected
+    # type.
     records = cursor.execute("SELECT * FROM logs").fetchall()
     for test_input, record in zip(test_inputs, records):
         tar_format = (

--- a/dagrunner/tests/utils/test_docstring_parse.py
+++ b/dagrunner/tests/utils/test_docstring_parse.py
@@ -2,8 +2,9 @@
 #
 # This file is part of 'dagrunner' and is released under the BSD 3-Clause license.
 # See LICENSE in the root of the repository for full licensing details.
-from dagrunner.utils import docstring_parse
 import pytest
+
+from dagrunner.utils import docstring_parse
 
 
 def markdown_style(arg1, arg2=None):

--- a/dagrunner/tests/utils/test_function_to_parse.py
+++ b/dagrunner/tests/utils/test_function_to_parse.py
@@ -111,7 +111,7 @@ Extended description of function.
 options:
   -h, --help          show this help message and exit
   --kwargs key value  Optional global keyword arguments to apply to all applicable plugins. Key-value pair argument.
-"""
+"""  # noqa: E501
     assert_help_str(help_str, tar)
 
     args = parser.parse_args(["--kwargs", "key1", "val1", "--kwargs", "key2", "val2"])

--- a/dagrunner/tests/utils/test_function_to_parse.py
+++ b/dagrunner/tests/utils/test_function_to_parse.py
@@ -2,12 +2,11 @@
 #
 # This file is part of 'dagrunner' and is released under the BSD 3-Clause license.
 # See LICENSE in the root of the repository for full licensing details.
-from io import StringIO
 import os
 import sys
+from io import StringIO
 
 from dagrunner.utils import function_to_argparse
-
 
 CALLING_MOD = os.path.basename(sys.argv[0])
 

--- a/dagrunner/tests/utils/visualisation/test_integration.py
+++ b/dagrunner/tests/utils/visualisation/test_integration.py
@@ -4,9 +4,9 @@
 # See LICENSE in the root of the repository for full licensing details.
 import tempfile
 
+from dagrunner.tests import assert_text_file_equal
 from dagrunner.utils import ObjectAsStr
 from dagrunner.utils.visualisation import visualise_graph
-from dagrunner.tests import assert_text_file_equal
 
 
 def test_basic():

--- a/dagrunner/utils/__init__.py
+++ b/dagrunner/utils/__init__.py
@@ -152,7 +152,8 @@ def function_to_argparse(func, parser=None, exclude=None):
     for name, param in singature_param:
         if param.kind == inspect.Parameter.VAR_POSITIONAL:
             print(
-                f"'function_to_argparse' parameter expansion '{param}' not supported yet"
+                f"'function_to_argparse' parameter expansion '{param}' not "
+                "supported yet"
             )
             continue
         if name in exclude:

--- a/dagrunner/utils/logger.py
+++ b/dagrunner/utils/logger.py
@@ -15,12 +15,11 @@ https://docs.python.org/3/howto/logging-cookbook.html#sending-and-receiving-logg
 import logging
 import logging.handlers
 import pickle
+import queue
 import socket
 import socketserver
 import struct
 import threading
-import queue
-
 
 __all__ = ["client_attach_socket_handler", "ServerContext"]
 
@@ -175,10 +174,10 @@ class SQLiteQueueHandler:
             print("Dequeued item:", record)
             cursor = self.db.cursor()
             cursor.execute(
-                """
-                INSERT INTO logs (created, name, level, message, hostname, process, thread)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
-            """,
+                "\n"
+                "INSERT INTO logs "
+                "(created, name, level, message, hostname, process, thread)\n"
+                "VALUES (?, ?, ?, ?, ?, ?, ?)\n",
                 (
                     record.created,
                     record.name,
@@ -206,7 +205,8 @@ class ServerContext:
     continue running other tasks.
 
     Log format is:
-    %(relativeCreated)5d %(name)-15s %(levelname)-8s %(hostname)s %(process)d %(asctime)s %(message)s
+    %(relativeCreated)5d %(name)-15s %(levelname)-8s %(hostname)s %(process)d
+    %(asctime)s %(message)s
 
     """
 
@@ -217,7 +217,10 @@ class ServerContext:
 
     def __enter__(self):
         logging.basicConfig(
-            format="%(relativeCreated)5d %(name)-15s %(levelname)-8s %(hostname)s %(process)d %(asctime)s %(message)s",
+            format=(
+                "%(relativeCreated)5d %(name)-15s %(levelname)-8s %(hostname)s "
+                "%(process)d %(asctime)s %(message)s"
+            ),
             datefmt="%Y-%m-%dT%H:%M:%S",
         )  # Date in ISO 8601 format
 

--- a/docs/dagrunner.plugin_framework.md
+++ b/docs/dagrunner.plugin_framework.md
@@ -32,12 +32,12 @@ exception if the timeout is reached.
 Args:
 - *args: Variable length argument list of file patterns to be checked.
 - timeout (int): Timeout in seconds (default is 120 seconds).
-- polling (int): Time interval in seconds between each poll (default is 1 second).
+- polling (int): Time interval in seconds between each poll (default is 1
+  second).
 - file_count (int): Expected number of files to be found (default is None).
     If specified, the total number of files found can be greater than the
     number of arguments.  Each argument is expected to return a minimum of
     1 match each in either case.
-
 
 Returns:
 - None
@@ -47,7 +47,7 @@ Raises:
 
 ## class: `Input`
 
-[Source](../dagrunner/plugin_framework.py#L117)
+[Source](../dagrunner/plugin_framework.py#L118)
 
 ### Call Signature:
 
@@ -61,7 +61,7 @@ that are 'node aware'.
 
 ### function: `__call__`
 
-[Source](../dagrunner/plugin_framework.py#L118)
+[Source](../dagrunner/plugin_framework.py#L119)
 
 #### Call Signature:
 
@@ -71,8 +71,9 @@ __call__(self, *args, filepath=None, **kwargs)
 
 Given a filepath, expand it and return this string
 
-Expand the provided filepath using the keyword arguments and environment variables.
-Note that this plugin is 'node aware' since it is derived from the `NodeAwarePlugin`.
+Expand the provided filepath using the keyword arguments and environment
+variables.  Note that this plugin is 'node aware' since it is derived from the
+`NodeAwarePlugin`.
 
 Args:
 - *args: Positional arguments are not accepted.
@@ -158,7 +159,7 @@ Returns:
 
 ## class: `SaveJson`
 
-[Source](../dagrunner/plugin_framework.py#L144)
+[Source](../dagrunner/plugin_framework.py#L146)
 
 ### Call Signature:
 
@@ -172,7 +173,7 @@ that are 'node aware'.
 
 ### function: `__call__`
 
-[Source](../dagrunner/plugin_framework.py#L145)
+[Source](../dagrunner/plugin_framework.py#L147)
 
 #### Call Signature:
 

--- a/docs/dagrunner.utils.logger.md
+++ b/docs/dagrunner.utils.logger.md
@@ -12,7 +12,7 @@ https://docs.python.org/3/howto/logging-cookbook.html#sending-and-receiving-logg
 
 ## class: `LogRecordSocketReceiver`
 
-[Source](../dagrunner/utils/logger.py#L105)
+[Source](../dagrunner/utils/logger.py#L104)
 
 ### Call Signature:
 
@@ -27,7 +27,7 @@ log records.
 
 ### function: `__init__`
 
-[Source](../dagrunner/utils/logger.py#L115)
+[Source](../dagrunner/utils/logger.py#L114)
 
 #### Call Signature:
 
@@ -39,7 +39,7 @@ Constructor.  May be extended, do not override.
 
 ### function: `serve_until_stopped`
 
-[Source](../dagrunner/utils/logger.py#L128)
+[Source](../dagrunner/utils/logger.py#L127)
 
 #### Call Signature:
 
@@ -49,7 +49,7 @@ serve_until_stopped(self, queue_handler=None)
 
 ### function: `stop`
 
-[Source](../dagrunner/utils/logger.py#L140)
+[Source](../dagrunner/utils/logger.py#L139)
 
 #### Call Signature:
 
@@ -59,7 +59,7 @@ stop(self)
 
 ## class: `LogRecordStreamHandler`
 
-[Source](../dagrunner/utils/logger.py#L56)
+[Source](../dagrunner/utils/logger.py#L55)
 
 ### Call Signature:
 
@@ -74,7 +74,7 @@ records and customise logging events.
 
 ### function: `handle`
 
-[Source](../dagrunner/utils/logger.py#L64)
+[Source](../dagrunner/utils/logger.py#L63)
 
 #### Call Signature:
 
@@ -88,7 +88,7 @@ according to whatever policy is configured locally.
 
 ### function: `handle_log_record`
 
-[Source](../dagrunner/utils/logger.py#L90)
+[Source](../dagrunner/utils/logger.py#L89)
 
 #### Call Signature:
 
@@ -98,7 +98,7 @@ handle_log_record(self, record)
 
 ### function: `unpickle`
 
-[Source](../dagrunner/utils/logger.py#L87)
+[Source](../dagrunner/utils/logger.py#L86)
 
 #### Call Signature:
 
@@ -108,7 +108,7 @@ unpickle(self, data)
 
 ## class: `SQLiteQueueHandler`
 
-[Source](../dagrunner/utils/logger.py#L145)
+[Source](../dagrunner/utils/logger.py#L144)
 
 ### Call Signature:
 
@@ -118,7 +118,7 @@ SQLiteQueueHandler(sqfile='logs.sqlite')
 
 ### function: `__init__`
 
-[Source](../dagrunner/utils/logger.py#L146)
+[Source](../dagrunner/utils/logger.py#L145)
 
 #### Call Signature:
 
@@ -130,7 +130,7 @@ Initialize self.  See help(type(self)) for accurate signature.
 
 ### function: `close`
 
-[Source](../dagrunner/utils/logger.py#L194)
+[Source](../dagrunner/utils/logger.py#L193)
 
 #### Call Signature:
 
@@ -140,7 +140,7 @@ close(self)
 
 ### function: `write`
 
-[Source](../dagrunner/utils/logger.py#L171)
+[Source](../dagrunner/utils/logger.py#L170)
 
 #### Call Signature:
 
@@ -150,7 +150,7 @@ write(self, log_queue)
 
 ## class: `ServerContext`
 
-[Source](../dagrunner/utils/logger.py#L199)
+[Source](../dagrunner/utils/logger.py#L198)
 
 ### Call Signature:
 
@@ -166,7 +166,8 @@ console.  The TC server is run in a separate thread enabling the main thread to
 continue running other tasks.
 
 Log format is:
-%(relativeCreated)5d %(name)-15s %(levelname)-8s %(hostname)s %(process)d %(asctime)s %(message)s
+%(relativeCreated)5d %(name)-15s %(levelname)-8s %(hostname)s %(process)d
+%(asctime)s %(message)s
 
 ### function: `__enter__`
 
@@ -180,7 +181,7 @@ __enter__(self)
 
 ### function: `__exit__`
 
-[Source](../dagrunner/utils/logger.py#L240)
+[Source](../dagrunner/utils/logger.py#L243)
 
 #### Call Signature:
 
@@ -202,7 +203,7 @@ Initialize self.  See help(type(self)) for accurate signature.
 
 ## function: `client_attach_socket_handler`
 
-[Source](../dagrunner/utils/logger.py#L28)
+[Source](../dagrunner/utils/logger.py#L27)
 
 ### Call Signature:
 
@@ -228,7 +229,7 @@ application:
 
 ## function: `main`
 
-[Source](../dagrunner/utils/logger.py#L245)
+[Source](../dagrunner/utils/logger.py#L248)
 
 ### Call Signature:
 

--- a/docs/dagrunner_index.md
+++ b/docs/dagrunner_index.md
@@ -1,5 +1,5 @@
 # Index for 'dagrunner' reference documentation
-version: 0.0.1dev
+version: {module.__version__}
 
   - [module: dagrunner](dagrunner.md#module-dagrunner)
     - [module: execute_graph](dagrunner.execute_graph.md#module-dagrunnerexecute_graph)

--- a/docs/gen_docs
+++ b/docs/gen_docs
@@ -6,9 +6,9 @@ Example usage:
     python generate_docs.py my_module /path/to/docs
 """
 
-import inspect
 import importlib
 import importlib.util
+import inspect
 import os
 import sys
 
@@ -87,10 +87,10 @@ def gen_obj_heading(level, obj, obname):
 
 def gen_obj_link(obj, obname, rel_mod_path=None):
     """
-    Generate a markdown link to an object i.e. to an objects corresponding markdown file.
+    Generate markdown link to an object i.e. to an objects corresponding markdown file.
 
-    rel_mod_path makes the link name relative to this module.  If None, the
-    link name is the full module path, while setting it to "" will remove the module path.
+    rel_mod_path makes the link name relative to this module.  If None, the link name
+    is the full module path, while setting it to "" will remove the module path.
     """
     heading = gen_obj_heading(0, obj, obname)
     heading = heading.strip().lower()
@@ -251,12 +251,14 @@ def generate_markdown_recursive(module_dot_path, target_root):
     toc_filepath = os.path.join(target_root, f"{module_dot_path}_index.md")
     with open(toc_filepath, "w") as f:
         f.write(
-            f"# Index for '{module_dot_path}' reference documentation\nversion: {module.__version__}\n\n"
+            f"# Index for '{module_dot_path}' reference documentation\nversion: "
+            "{module.__version__}\n\n"
         )
     index = []
 
     for root, _, filenames in os.walk(module.__path__[0]):
-        # Check if any component of the root path is hidden ('.'), private ('_') or is testing ('tests')
+        # Check if any component of the root path is hidden ('.'), private ('_') or is
+        # testing ('tests')
         if any(
             part.startswith(".") or part.startswith("_") or part.startswith("tests")
             for part in root.split(os.path.sep)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,3 +37,10 @@ Repository = "https://github.com/MetOffice/dagrunner"
 
 [project.scripts]
 dagrunner-execute-graph = "dagrunner.execute_graph:main"
+
+[tool.ruff.lint]
+extend-select = ["E", "F", "W", "I"]
+
+[tool.ruff.format]
+# Enable reformatting of code snippets in docstrings.
+docstring-code-format = true


### PR DESCRIPTION
Following on from the previous PR which switched to `ruff`.  We now include E (pycodestyle), W and I (isort) rules.
Making it equivalent to what we had before ruff (flake8, isort, black), except without the McCabe for now.

See [pyproject.toml
 changes](https://github.com/MetOffice/dagrunner/pull/47/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711)

Additionally:
- In my haste I didn't modify the reference pytest call in CI to match what I did to the other.  That is, addressing hidden failure and running a failing logging test.  See [CI changes](https://github.com/MetOffice/dagrunner/pull/47/files#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fR71).

Everything else if changes to address any formatting changes.

## Issues

- https://github.com/MetOffice/improver_suite/issues/2214

## Note

Could we include more rules??  All rules perhaps??  Yes, but this PR is only to reintroduce rules we had in place as part of flake8 + isort + black right now.
The future configuration of ruff needs some further thought.