### PR TITLE
ENH: Recursive filepath expansion

### DIFF
--- a/dagrunner/plugin_framework.py
+++ b/dagrunner/plugin_framework.py
@@ -138,9 +138,16 @@ class Input(NodeAwarePlugin):
         """
         if args:
             raise ValueError("Input plugin does not accept positional arguments")
-        return os.path.expanduser(
-            string.Template(filepath.format(**kwargs)).substitute(os.environ)
-        )
+
+        def expand(pstring):
+            res = os.path.expanduser(
+                string.Template(pstring.format(**kwargs)).substitute(os.environ)
+            )
+            if "{" in res and "}" in res:
+                return expand(res)
+            return res
+
+        return expand(filepath)
 
 
 class SaveJson(Input):

--- a/dagrunner/tests/plugin_framework/test_Input.py
+++ b/dagrunner/tests/plugin_framework/test_Input.py
@@ -1,0 +1,31 @@
+# (C) Crown Copyright, Met Office. All rights reserved.
+#
+# This file is part of 'dagrunner' and is released under the BSD 3-Clause license.
+# See LICENSE in the root of the repository for full licensing details.
+import os
+
+from dagrunner.plugin_framework import Input
+
+
+def test_basic():
+    input = Input()
+    os.environ["SOME_ROOT"] = "/path/to/data"
+    kwargs = {
+        "current_cycle": "20210101T0000Z",
+        "data_input_path": "input",
+    }
+    filepath = "$SOME_ROOT/{data_input_path}/{current_cycle}"
+    res = input(filepath=filepath, **kwargs)
+    assert res == "/path/to/data/input/20210101T0000Z"
+
+
+def test_recursive():
+    # Expand twice
+    input = Input()
+    kwargs = {
+        "current_cycle": "20210101T0000Z",
+        "data_input_path": "{current_cycle}",
+    }
+    filepath = "{data_input_path}"
+    res = input(filepath=filepath, **kwargs)
+    assert res == "20210101T0000Z"

--- a/docs/dagrunner.plugin_framework.md
+++ b/docs/dagrunner.plugin_framework.md
@@ -159,7 +159,7 @@ Returns:
 
 ## class: `SaveJson`
 
-[Source](../dagrunner/plugin_framework.py#L146)
+[Source](../dagrunner/plugin_framework.py#L153)
 
 ### Call Signature:
 
@@ -173,7 +173,7 @@ that are 'node aware'.
 
 ### function: `__call__`
 
-[Source](../dagrunner/plugin_framework.py#L147)
+[Source](../dagrunner/plugin_framework.py#L154)
 
 #### Call Signature:
 


### PR DESCRIPTION
Make Input plugin recursively expand the string.  This enables having a formatting string embedded within a formatting string.
We want to avoid at all cost referencing any environment variables directly within science configurations.  Note that filepath patterns themselves can be constructed from environment variables and that's fine - these are then expanded by the plugin.  We simply don't want to hardcode environment variable names anywhere within the configuration itself).

## What does this mean?

Defining filepaths within the orchestration layer, rather than hardcoding them within the configuration itself.

```python
input_settings = {
    "call": (
        "graph_config.plugins.Input",
        {
            "current_cycle": None,
            "data_input_path": None,
            "filepath": "{data_input_path}",
        },
        
    )
}
```

Illustrative json template variables within the orchestration:
```
{%- set DATA_INPUT_PATH = {
    "config1": "/path/to/share/cycle/{cyclepoint:%Y%m%dT%H%MZ}/decoupler/bla/teacup*/level_1/{validitytime:%Y%m%dT%H%MZ}-{isoleadtime}-{diagnostic}.nc",
    "config2": "/path/to/share/cycle/{cyclepoint:%Y%m%dT%H%MZ}/decoupler/bling/bleh*/level_1/{validitytime:%Y%m%dT%H%MZ}-{isoleadtime}-{diagnostic}.nc",
    }
%}
```

## Issues

- https://github.com/MetOffice/improver_suite/issues/2253
- https://github.com/MetOffice/improver_suite/issues/2079