### PR TITLE
Node execution skip propagation

### DIFF
--- a/dagrunner/runner/schedulers/asyncmp.py
+++ b/dagrunner/runner/schedulers/asyncmp.py
@@ -108,7 +108,7 @@ class AsyncMP:
                             async_res.get()  # remote traceback
                         except Exception as err:
                             self._failures_found = True
-                            command = " ".join(graph[target][2:])
+                            command = str(graph[target])
                             raise RuntimeError(
                                 f"Command failure, key: '{target}'\ncommand:{command}"
                             ) from err


### PR DESCRIPTION
I have previously added the `SkipBranch` exception which may allow some capability for skipping node execution but this precludes serial schedulers.  The approach applied here is to have a plugin return a SKIP_EVENT signal which is in turn propagated throughout successive nodes.

- Added SKIP_EVENT singleton which indicates to the `plugin_executor` to skip execution.  This then allows propagation along the execution network.
- Minor fix to the in-house multiprocessing error handling code.