### PR TITLE
ENH: Visualisation of nodes containing unsortable property values

### DIFF
--- a/dagrunner/tests/utils/networkx/test_integration.py
+++ b/dagrunner/tests/utils/networkx/test_integration.py
@@ -107,6 +107,23 @@ def test_special_characters_words(graph):
     assert_visual(graph, "mermaid")
 
 
+def test_node_properties_unsortable_types(graph):
+    # Mixed types that are not sortable
+    # Here we assign a diagnostic name of integer 0 while the remaining nodes remain
+    # are strings.
+    node_0, node_0_data = _gen_node(0, 1)
+    graph.add_node(node_0, **node_0_data)
+
+    with mock.patch("dagrunner.utils.networkx.visualise_graph_mermaid") as mock_mermaid:
+        visualise_graph(
+            graph,
+            backend="mermaid",
+            output_filepath=mock.sentinel.output_filepath,
+            collapse_properties=["diagnostic"],
+        )
+    mock_mermaid.assert_called_once()
+
+
 @pytest.fixture
 def mock_mpl_backend():
     with mock.patch(

--- a/dagrunner/utils/networkx.py
+++ b/dagrunner/utils/networkx.py
@@ -365,12 +365,17 @@ def visualise_graph(
                 filter(lambda gnode: subset_equality(node, gnode), graph.nodes)
             )
             node_info_lookup[node] = {
-                property: sorted(
-                    set([getattr(node, property) for node in filtered_nodes]),
-                    key=lambda x: (x is None, x),
-                )
+                property: set([getattr(node, property) for node in filtered_nodes])
                 for property in collapse_properties
             }
+            for key in node_info_lookup[node]:
+                try:
+                    node_info_lookup[node][key] = sorted(
+                        node_info_lookup[node][key], key=lambda x: (x is None, x)
+                    )
+                except TypeError:
+                    continue
+
             node_info_lookup[node].update(
                 {
                     "node data": set(


### PR DESCRIPTION
Only comes up with visualising improver configurations (as they are defined today, not future ones) since some node properties contain a mixture of strings and integers and so aren't sortable (e.g. some nodes containing a 'cycle' integer list while others contain 'R1' string syntax for cylc).

```python
                node_info_lookup[node] = {
>                   property: sorted(
                        set([getattr(node, property) for node in filtered_nodes]),
                        key=lambda x: (x is None, x),
                    )
                    for property in collapse_properties
                }
E               TypeError: '<' not supported between instances of 'str' and 'int'
```

Visualisation of improver ukvx:

```python
    visualise_graph(graph, title=suite_name, collapse_properties=['step', 'leadtime', 'offset'],
                    label_by=["system", "model"], group_by=["chain"])
```

![image](https://github.com/user-attachments/assets/3bc55824-8d9b-4083-b6ae-7618931b873a)

## Issues

- https://github.com/MetOffice/improver_suite/issues/2079