### PR TITLE
DOC: Actions doc auto-build include new files

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -188,6 +188,7 @@ jobs:
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add docs/.
           git commit -am "Automated reference documentation update for PR ${{ github.event.number }} [skip ci]"
           git push
         env:

--- a/docs/dagrunner.config.md
+++ b/docs/dagrunner.config.md
@@ -1,0 +1,133 @@
+# module: `dagrunner.config`
+
+[Source](../dagrunner/config.py#L0)
+
+This module handles the run-time configuration of the dagrunner library.
+
+Certain hooks are present in the library for providing detailed control over
+dagrunner run-time.
+
+The configuration of dagrunner follows a first-in first-out approach on parsing
+configuration options and is handled by :class:`dagrunner.config.GlobalConfiguration`.
+This means that any number of configuration files can be parsed.  On import,
+`dagrunner.cfg` is parsed when present in the dagrunner root folder.  Each successive
+configuration file parsing will override existing parameter values.
+
+see [class: dagrunner.utils.Singleton](dagrunner.utils.md#class-singleton)
+
+## GlobalConfiguration: `CONFIG`
+
+## class: `GlobalConfiguration`
+
+[Source](../dagrunner/config.py#L28)
+
+### Call Signature:
+
+```python
+GlobalConfiguration(*args, **kwargs)
+```
+
+The global configuration class handles any number of configuration files,
+where subsequent configuration entries act to override previous entries
+parsed.
+
+All group names parsed are prefixed with "dagrunner" and all entries are then
+parsed strictly.  Those groups not with this prefix are silently ignored.
+
+The following represents a description of the runtime configuration
+options::
+
+    # Graph visualisation
+    [dagrunner_visualisation]
+    enabled
+    title
+    collapse_properties
+    backend
+    output_filepath
+    group_by
+    label_by
+
+    [dagrunner_runtime]
+
+    # Logging
+    [dagrunner_logging]
+    enabled
+    host
+    port
+
+### function: `__getitem__`
+
+[Source](../dagrunner/config.py#L166)
+
+#### Call Signature:
+
+```python
+__getitem__(self, key)
+```
+
+### function: `__init__`
+
+[Source](../dagrunner/config.py#L77)
+
+#### Call Signature:
+
+```python
+__init__(self)
+```
+
+Initialize self.  See help(type(self)) for accurate signature.
+
+### function: `__repr__`
+
+[Source](../dagrunner/config.py#L84)
+
+#### Call Signature:
+
+```python
+__repr__(self)
+```
+
+Return repr(self).
+
+### function: `__setitem__`
+
+[Source](../dagrunner/config.py#L169)
+
+#### Call Signature:
+
+```python
+__setitem__(self, key, value)
+```
+
+### function: `__str__`
+
+[Source](../dagrunner/config.py#L81)
+
+#### Call Signature:
+
+```python
+__str__(self)
+```
+
+Return str(self).
+
+### function: `parse_configuration`
+
+[Source](../dagrunner/config.py#L140)
+
+#### Call Signature:
+
+```python
+parse_configuration(self, filename)
+```
+
+Parses a new configuration file.
+
+Entries in 'filename' override existing entries in the configuration,
+while entries not set remain unchanged from the previous state.
+
+Parameters
+----------
+filename : str
+    Name of the configuration file to read.
+

--- a/docs/dagrunner.utils.logger.md
+++ b/docs/dagrunner.utils.logger.md
@@ -59,7 +59,7 @@ attributes in a LogRecord are described by:
 %(lineno)d          Source line number where the logging call was issued
                     (if available)
 %(funcName)s        Function name
-%(created)f         Time when the LogRecord was created (time.time()
+%(created)f         Time when the LogRecord was created (time.time_ns() / 1e9
                     return value)
 %(asctime)s         Textual time when the LogRecord was created
 %(msecs)d           Millisecond portion of the creation time

--- a/docs/dagrunner.utils.md
+++ b/docs/dagrunner.utils.md
@@ -152,7 +152,7 @@ Returns:
 ### Call Signature:
 
 ```python
-KeyValueAction(option_strings, dest, nargs=None, const=None, default=None, type=None, choices=None, required=False, help=None, metavar=None)
+KeyValueAction(option_strings, dest, nargs=None, const=None, default=None, type=None, choices=None, required=False, help=None, metavar=None, deprecated=False)
 ```
 
 Information about how to convert command line strings to Python objects.

--- a/docs/dagrunner.utils.networkx.md
+++ b/docs/dagrunner.utils.networkx.md
@@ -1,0 +1,102 @@
+# module: `dagrunner.utils.networkx`
+
+[Source](../dagrunner/utils/networkx.py#L0)
+
+see [class: dagrunner.utils.visualisation.HTMLTable](dagrunner.utils.visualisation.md#class-htmltable)
+
+see [class: dagrunner.utils.visualisation.MermaidGraph](dagrunner.utils.visualisation.md#class-mermaidgraph)
+
+see [class: dagrunner.utils.visualisation.MermaidHTML](dagrunner.utils.visualisation.md#class-mermaidhtml)
+
+see [function: dagrunner.utils.as_iterable](dagrunner.utils.md#function-as_iterable)
+
+see [function: dagrunner.utils.in_notebook](dagrunner.utils.md#function-in_notebook)
+
+see [function: dagrunner.utils.subset_equality](dagrunner.utils.md#function-subset_equality)
+
+## function: `get_subset_with_dependencies`
+
+[Source](../dagrunner/utils/networkx.py#L55)
+
+### Call Signature:
+
+```python
+get_subset_with_dependencies(graph: networkx.classes.digraph.DiGraph, filter_list: Iterable)
+```
+
+Helper function to easily filter networkx graphs.
+
+Each item in our filter list determines whether its node should be included or
+excluded.
+
+Args:
+- `graph`: The graph to filter.
+- `filter_list`: The list of filters to apply.
+    Each item in this list should take the form:
+        {node: <node>, exclude: <bool>, descendants: <bool>, ancestors: <bool>}
+
+## function: `visualise_graph`
+
+[Source](../dagrunner/utils/networkx.py#L320)
+
+### Call Signature:
+
+```python
+visualise_graph(graph: networkx.classes.digraph.DiGraph, backend='mermaid', collapse_properties: Iterable = None, title=None, output_filepath=None, **kwargs)
+```
+
+Visualise a networkx graph.
+
+Plots each disconnected branch of nodes with their connected edges of its own
+distinct color.  Intended for plotting small graphs, whether filtered (e.g. a graph
+filtered for a specific leadtime or diagnostic) and or collapsed along specified
+dimensions (e.g. collapsing along the 'leadtime' property).
+
+Args:
+- `graph`: The graph to visualise.
+- `backend`: The backend to use for visualisation.  Supported values include
+  'mermaid' (javascript, default) and 'matplotlib'.
+- `collapse_properties`: A list of properties to collapse nodes on.  Only
+  supported for nodes represented by dataclasses right now.
+- `title`: The title of the visualisation.
+- `output_filepath`: The output filepath to save the visualisation to.
+
+## function: `visualise_graph_matplotlib`
+
+[Source](../dagrunner/utils/networkx.py#L116)
+
+### Call Signature:
+
+```python
+visualise_graph_matplotlib(graph: networkx.classes.digraph.DiGraph, node_info_lookup: dict = None, title: str = None, output_filepath: str = None)
+```
+
+Visualise a networkx graph using matplotlib.
+
+Note that this backend is provided as-is and not intended for production use.
+'mermaid' graph is the recommended approach to graph visualisation.
+
+Args:
+- `graph`: The graph to visualise.
+- `node_info_lookup`: A dictionary mapping nodes to their information.
+- `title`: The title of the visualisation.
+- `output_filepath`: The output filepath to save the visualisation to.
+
+## function: `visualise_graph_mermaid`
+
+[Source](../dagrunner/utils/networkx.py#L214)
+
+### Call Signature:
+
+```python
+visualise_graph_mermaid(graph: networkx.classes.digraph.DiGraph, node_info_lookup: dict = None, title: str = None, output_filepath: str = None, group_by: str = None, label_by: Iterable = None)
+```
+
+Visualise a networkx graph using matplotlib.
+
+Args:
+- `graph`: The graph to visualise.
+- `node_info_lookup`: A dictionary mapping nodes to their information.
+- `title`: The title of the visualisation.
+- `output_filepath`: The output filepath to save the visualisation to.
+


### PR DESCRIPTION
Currently, only modified documentation files are part of the automated bot commit - files that aren't under version control are not.  This is an oversight.  This is a simple fix to the missing documentation problem.

## Issues

- Closes https://github.com/MetOffice/dagrunner/issues/71
- https://github.com/MetOffice/pp_demo_workflow/issues/32
- https://github.com/MetOffice/improver_suite/issues/2394
- https://github.com/MetOffice/improver_suite/issues/2395
- https://github.com/MetOffice/improver_suite/issues/2214
- https://github.com/MetOffice/improver_suite/issues/2253