### PR TITLE
Some graph rendering broken after 11.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -105,7 +105,7 @@ jobs:
         if: steps.cache-ref-coverage.outputs.cache-hit != 'true'
         run: |
           cd ref
-          pytest --cov=dagrunner --cov-report=term --cov-report=html | tee coverage_output.txt; test ${PIPESTATUS[0]} -eq 0
+          pytest --maxfail=0 --continue-on-collection-errors --cov=dagrunner --cov-report=term --cov-report=html | tee coverage_output.txt || true
 
       # TESTS (compare coverage)
       ############################

--- a/dagrunner/tests/results/dagrunner.tests.utils.networkx.test_integration.test_basic.html
+++ b/dagrunner/tests/results/dagrunner.tests.utils.networkx.test_integration.test_basic.html
@@ -119,7 +119,8 @@ click 9 callback "{'node data': {'call': ('module.path.e',<br>{'init_arg': 'ia_e
 </div>
 
 <script type="module">
-  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+  // pin mermaid version to 11.0: https://github.com/MetOffice/dagrunner/pull/75
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11.0/dist/mermaid.esm.min.mjs';
   mermaid.initialize({
         startOnLoad: true,
         flowchart: { useMaxWidth: false, htmlLabels: true, curve: 'basis' },

--- a/dagrunner/tests/results/dagrunner.tests.utils.networkx.test_integration.test_collapse_properties.html
+++ b/dagrunner/tests/results/dagrunner.tests.utils.networkx.test_integration.test_collapse_properties.html
@@ -105,7 +105,8 @@ click 4 callback "{'leadtime': [1, 2],<br>'node data': {{'call': ('module.path.e
 </div>
 
 <script type="module">
-  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+  // pin mermaid version to 11.0: https://github.com/MetOffice/dagrunner/pull/75
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11.0/dist/mermaid.esm.min.mjs';
   mermaid.initialize({
         startOnLoad: true,
         flowchart: { useMaxWidth: false, htmlLabels: true, curve: 'basis' },

--- a/dagrunner/tests/results/dagrunner.tests.utils.networkx.test_integration.test_groupby.html
+++ b/dagrunner/tests/results/dagrunner.tests.utils.networkx.test_integration.test_groupby.html
@@ -139,7 +139,8 @@ end
 </div>
 
 <script type="module">
-  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+  // pin mermaid version to 11.0: https://github.com/MetOffice/dagrunner/pull/75
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11.0/dist/mermaid.esm.min.mjs';
   mermaid.initialize({
         startOnLoad: true,
         flowchart: { useMaxWidth: false, htmlLabels: true, curve: 'basis' },

--- a/dagrunner/tests/results/dagrunner.tests.utils.networkx.test_integration.test_properties_of_none.html
+++ b/dagrunner/tests/results/dagrunner.tests.utils.networkx.test_integration.test_properties_of_none.html
@@ -121,7 +121,8 @@ click 10 callback "{'node data': {'call': ('module.path.z',<br>{'init_arg': 'ia_
 </div>
 
 <script type="module">
-  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@9/dist/mermaid.esm.min.mjs';
+  // pin mermaid version to 11.0: https://github.com/MetOffice/dagrunner/pull/75
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11.0/dist/mermaid.esm.min.mjs';
   mermaid.initialize({
         startOnLoad: true,
         flowchart: { useMaxWidth: false, htmlLabels: true, curve: 'basis' },

--- a/dagrunner/tests/results/dagrunner.tests.utils.networkx.test_integration.test_special_characters_words.html
+++ b/dagrunner/tests/results/dagrunner.tests.utils.networkx.test_integration.test_special_characters_words.html
@@ -119,7 +119,8 @@ click 9 callback "{'node data': {'call': ('module.path.e',<br>{'init_arg': 'ia_e
 </div>
 
 <script type="module">
-  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+  // pin mermaid version to 11.0: https://github.com/MetOffice/dagrunner/pull/75
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11.0/dist/mermaid.esm.min.mjs';
   mermaid.initialize({
         startOnLoad: true,
         flowchart: { useMaxWidth: false, htmlLabels: true, curve: 'basis' },

--- a/dagrunner/utils/visualisation.py
+++ b/dagrunner/utils/visualisation.py
@@ -200,7 +200,7 @@ td {{
 </div>
 
 <script type="module">
-  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11.0/dist/mermaid.esm.min.mjs';
   mermaid.initialize({{
         startOnLoad: true,
         flowchart: {{ useMaxWidth: false, htmlLabels: true, curve: 'basis' }},

--- a/dagrunner/utils/visualisation.py
+++ b/dagrunner/utils/visualisation.py
@@ -200,6 +200,7 @@ td {{
 </div>
 
 <script type="module">
+  // pin mermaid version to 11.0: https://github.com/MetOffice/dagrunner/pull/75
   import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11.0/dist/mermaid.esm.min.mjs';
   mermaid.initialize({{
         startOnLoad: true,

--- a/docs/dagrunner.utils.networkx.md
+++ b/docs/dagrunner.utils.networkx.md
@@ -21,7 +21,7 @@ see [function: dagrunner.utils.subset_equality](dagrunner.utils.md#function-subs
 ### Call Signature:
 
 ```python
-get_subset_with_dependencies(graph: networkx.classes.digraph.DiGraph, filter_list: Iterable)
+get_subset_with_dependencies(graph: networkx.classes.digraph.DiGraph, filter_list: Union[dict, Iterable[dict]])
 ```
 
 Helper function to easily filter networkx graphs.
@@ -37,12 +37,12 @@ Args:
 
 ## function: `visualise_graph`
 
-[Source](../dagrunner/utils/networkx.py#L320)
+[Source](../dagrunner/utils/networkx.py#L325)
 
 ### Call Signature:
 
 ```python
-visualise_graph(graph: networkx.classes.digraph.DiGraph, backend='mermaid', collapse_properties: Iterable = None, title=None, output_filepath=None, **kwargs)
+visualise_graph(graph: networkx.classes.digraph.DiGraph, backend: str = 'mermaid', collapse_properties: Union[str, Iterable[str]] = None, title: str = None, output_filepath: str = None, **kwargs)
 ```
 
 Visualise a networkx graph.
@@ -56,14 +56,15 @@ Args:
 - `graph`: The graph to visualise.
 - `backend`: The backend to use for visualisation.  Supported values include
   'mermaid' (javascript, default) and 'matplotlib'.
-- `collapse_properties`: A list of properties to collapse nodes on.  Only
+  See [visualise_graph_mermaid](#function-visualise_graph_mermaid).
+- `collapse_properties`: One or more properties to collapse nodes on.  Only
   supported for nodes represented by dataclasses right now.
 - `title`: The title of the visualisation.
 - `output_filepath`: The output filepath to save the visualisation to.
 
 ## function: `visualise_graph_matplotlib`
 
-[Source](../dagrunner/utils/networkx.py#L116)
+[Source](../dagrunner/utils/networkx.py#L117)
 
 ### Call Signature:
 
@@ -84,19 +85,22 @@ Args:
 
 ## function: `visualise_graph_mermaid`
 
-[Source](../dagrunner/utils/networkx.py#L214)
+[Source](../dagrunner/utils/networkx.py#L215)
 
 ### Call Signature:
 
 ```python
-visualise_graph_mermaid(graph: networkx.classes.digraph.DiGraph, node_info_lookup: dict = None, title: str = None, output_filepath: str = None, group_by: str = None, label_by: Iterable = None)
+visualise_graph_mermaid(graph: networkx.classes.digraph.DiGraph, node_info_lookup: dict = None, title: str = None, output_filepath: str = None, group_by: Union[str, Iterable[str]] = None, label_by: Union[str, Iterable[str]] = None)
 ```
 
-Visualise a networkx graph using matplotlib.
+Visualise a networkx graph using mermaid.
 
 Args:
 - `graph`: The graph to visualise.
 - `node_info_lookup`: A dictionary mapping nodes to their information.
 - `title`: The title of the visualisation.
 - `output_filepath`: The output filepath to save the visualisation to.
+- `group_by`: One or more property to group nodes by (i.e.
+  [subgraph](https://mermaid-js.github.io/mermaid/#/subgraph)).
+- `label_by`: One or more property to label visualisation nodes by.
 

--- a/docs/dagrunner.utils.visualisation.md
+++ b/docs/dagrunner.utils.visualisation.md
@@ -134,7 +134,7 @@ MermaidHTML(mermaid, table=None)
 
 ### function: `__init__`
 
-[Source](../dagrunner/utils/visualisation.py#L321)
+[Source](../dagrunner/utils/visualisation.py#L322)
 
 #### Call Signature:
 
@@ -146,7 +146,7 @@ Initialize self.  See help(type(self)) for accurate signature.
 
 ### function: `__str__`
 
-[Source](../dagrunner/utils/visualisation.py#L324)
+[Source](../dagrunner/utils/visualisation.py#L325)
 
 #### Call Signature:
 
@@ -158,7 +158,7 @@ Return str(self).
 
 ### function: `save`
 
-[Source](../dagrunner/utils/visualisation.py#L329)
+[Source](../dagrunner/utils/visualisation.py#L330)
 
 #### Call Signature:
 


### PR DESCRIPTION
I have raised an issue with the mermaid repository here: https://github.com/mermaid-js/mermaid/issues/6251
Not all graph rendering is broken, only seemingly large ones.

## Background

We recently bumped mermaid version in https://github.com/MetOffice/dagrunner/pull/74 (using latest).
Everything works fine in our small graph rendering examples (integration tests).  Upon rendering full configurations the issue presents (some configurations).

![image](https://github.com/user-attachments/assets/a738251c-08b9-44c9-8a14-23add5999ee0)