### PR TITLE
Extend plugin_executor to catch warnings during msg construction and …

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -184,7 +184,8 @@ jobs:
       # success of all previous steps.  A pushed commit will not trigger the re-running
       # of this workflow.
       - name: Commit and push documentation changes
-        if: steps.check-docs.outputs.changed == 'true'
+
+        if: ${{ steps.check-docs.outputs.changed == 'true' && !github.event.pull_request.head.repo.fork }}
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,8 +14,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}  # Ensure branch is checked out, not detached state (so we can push a commit later)
-          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.event.pull_request.head.ref }}  # Ensure branch is checked out, not detached state (so we can push a commit later)
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -55,8 +55,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}  # Ensure branch is checked out, not detached state (so we can push a commit later)
-          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.event.pull_request.head.ref }}  # Ensure branch is checked out, not detached state (so we can push a commit later)
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/dagrunner/execute_graph.py
+++ b/dagrunner/execute_graph.py
@@ -6,6 +6,7 @@
 import importlib
 import inspect
 import logging
+import warnings
 from functools import partial
 
 import dask
@@ -193,7 +194,15 @@ def plugin_executor(
         callable_obj, common_kwargs, callable_kwargs.keys()
     )  # based on overriding arguments
 
-    msg = f"{obj_name}{call_msg}(*{args}, **{callable_kwargs})"
+    obj_path = get_object_path(callable_obj)
+    with warnings.catch_warnings(record=True) as caught_warnings:
+        msg = f"{obj_name}{call_msg}(*{args}, **{callable_kwargs})"
+    for warning in caught_warnings:
+        warnings.warn(
+            message=f"[Plugin: {obj_path}] | {warning.message}",
+            category=warning.category,
+        )
+
     if verbose:
         print(msg)
     res = None
@@ -269,6 +278,20 @@ def _get_networkx(networkx_graph):
                 "Not recognised 'networkx_graph' parameter, see ExecuteGraph docstring."
             )
     return nxgraph
+
+
+def get_object_path(obj):
+    """Attempt to retrieve the path for the given object."""
+    obj_path = "unknown"
+    if isinstance(obj, str):
+        obj_path = obj
+    elif inspect.isclass(obj):
+        obj_path = inspect.getfile(obj)
+    elif inspect.isfunction(obj):
+        obj_path = inspect.getfile(obj)
+    elif hasattr(obj, "__class__") and not inspect.isclass(obj):
+        obj_path = inspect.getfile(obj.__class__)
+    return obj_path
 
 
 class ExecuteGraph:

--- a/dagrunner/tests/execute_graph/test_get_object_path.py
+++ b/dagrunner/tests/execute_graph/test_get_object_path.py
@@ -1,0 +1,28 @@
+# (C) Crown Copyright, Met Office. All rights reserved.
+#
+# This file is part of 'dagrunner' and is released under the BSD 3-Clause license.
+# See LICENSE in the root of the repository for full licensing details.
+import os
+
+import pytest
+
+from dagrunner.execute_graph import get_object_path
+
+
+def test_func(): ...
+
+
+class TestClass: ...
+
+
+TEST_INSTANCE = TestClass()
+TEST_LAMBDA = lambda: None
+TEST_STRING = os.path.abspath(__file__)
+
+TEST_CASES = [test_func, TestClass, TEST_INSTANCE, TEST_LAMBDA, TEST_STRING]
+
+
+@pytest.mark.parametrize("test_object", TEST_CASES)
+def test_get_object_path(test_object):
+    """Test get_object_path with parametrized range of objects."""
+    assert os.path.abspath(__file__) == get_object_path(test_object)


### PR DESCRIPTION
Extend `plugin_executor` to catch warnings during msg construction and append the plugin filepath to the warning message.

When running workflows with dagrunner it is possible that warnings will be generated inside plugin code when the log message for verbose logging is created, because args and kwargs can contain objects with `__str__` methods which can execute arbitrary code where such code is present in the plugin module.

One such example was `import iris` which generated the `iris.FUTURE` warnings in way that was hard to trace because they appeared to originate directly from iris or from dagrunner execute_graph depending on how the workflow was being run.

This change implements the solution defined in https://github.com/MetOffice/dagrunner/issues/103 whereby we catch any warnings emitted during string creation and extend those warnings with information about the application path to better communicate the plugin responsible for the warning.