### PR TITLE
Stop escaping special characters in mermaid tooltips

### DIFF
--- a/visual/mermaid-table-standard.js
+++ b/visual/mermaid-table-standard.js
@@ -78,6 +78,7 @@ class TableStandardFmt extends HTMLElement {
 
     connectedCallback() {
         this.render();
+        this.setupMermaidTooltipLineBreakFix();
         this.registerMermaidClickCallback();
         this.setupRowClickHandling();
         this.setupMermaid();
@@ -89,6 +90,69 @@ class TableStandardFmt extends HTMLElement {
         this.setupThemeToggle();
         this.setupTableHeaderClickHandling();
         this.setupTextNewlineDelimToggle();
+    }
+
+    setupMermaidTooltipLineBreakFix() {
+        // Mermaid tooltips are rendered in light DOM (outside shadow root).
+        // Normalize common escaped/newline forms to real <br> tags.
+        if (window.__mermaidTooltipLineBreakFixInstalled) {
+            return;
+        }
+
+        const normalizeTooltip = (tooltip) => {
+            if (!tooltip) {
+                return;
+            }
+
+            const original = tooltip.innerHTML;
+            const normalized = original
+                .replace(/&lt;\s*\/\s*br\s*&gt;/gi, '<br>')
+                .replace(/&lt;\s*br\s*\/?\s*&gt;/gi, '<br>')
+                .replace(/<\s*\/\s*br\s*>/gi, '<br>')
+                .replace(/\\n/g, '<br>')
+                .replace(/\r\n|\r|\n/g, '<br>');
+
+            if (normalized !== original) {
+                tooltip.innerHTML = normalized;
+            }
+        };
+
+        const observeTooltip = (tooltip) => {
+            if (!tooltip || tooltip.__lineBreakObserverInstalled) {
+                return;
+            }
+
+            tooltip.__lineBreakObserverInstalled = true;
+            normalizeTooltip(tooltip);
+
+            const tooltipObserver = new MutationObserver(() => {
+                normalizeTooltip(tooltip);
+            });
+
+            tooltipObserver.observe(tooltip, {
+                childList: true,
+                subtree: true,
+                characterData: true
+            });
+        };
+
+        const scanForTooltips = () => {
+            document.querySelectorAll('div.mermaidTooltip').forEach(observeTooltip);
+        };
+
+        const bodyObserver = new MutationObserver(() => {
+            scanForTooltips();
+        });
+
+        if (document.body) {
+            bodyObserver.observe(document.body, {
+                childList: true,
+                subtree: true
+            });
+        }
+
+        scanForTooltips();
+        window.__mermaidTooltipLineBreakFixInstalled = true;
     }
 
     registerMermaidClickCallback() {


### PR DESCRIPTION
Something I had been meaning to get to in quite some time.

`<br>` tags aren't being recognized as newlines in Mermaid tooltips when used within my custom web component (`mermaid-table-standard.js`), even though they normally work in standard Mermaid diagrams.

Web components often escape special characters (like `<`, `>`, and `/`) by default when interpolating values into templates. `<br>` may then be rendered as plain text (`&lt;br&gt;`) instead of being interpreted as an HTML line break.

Added MutationObserver-based rebinding so this keeps working across Mermaid re-renders/theme toggles.

## Test

**Before change:**

<img width="538" height="200" alt="image" src="https://github.com/user-attachments/assets/8c6beeee-f9d6-43b4-a7ac-49a5aeeeb7ce" />

**After change:**

<img width="534" height="195" alt="image" src="https://github.com/user-attachments/assets/75d5c469-7480-4216-a4cb-c21fbbf89504" />
