### PR TITLE
Allow DAGrunner to propagate an `IGNORE_EVENT` with only one input argument

### DIFF
--- a/dagrunner/events.py
+++ b/dagrunner/events.py
@@ -7,28 +7,28 @@
 DAGrunner defines two special singleton events that plugins can return to control the
 execution flow of their graph.
 
-- event.IGNORE - removes a particular input from further processing.
-- event.SKIP -  aborts the execution of a plugin (and all downstream nodes) when any
+- IGNORE_EVENT - removes a particular input from further processing.
+- SKIP_EVENT -  aborts the execution of a plugin (and all downstream nodes) when any
   input carries this event.
 
 
-### event.IGNORE
-When a plugin returns `event.IGNORE`, the immediate descendant node filters out that
+### _IgnoreEvent: `IGNORE_EVENT`
+When a plugin returns `IGNORE_EVENT`, the immediate descendant node filters out that
 input.
 The remaining inputs of that plugin are utilised by that node as normal.
-If all inputs to a node are `event.IGNORE`, the node's execution is skipped, and a
-`event.SKIP` event is returned instead, skipping execution through all descendants.
+If all inputs to a node are `IGNORE_EVENT`, the node's execution is skipped, and a
+`SKIP_EVENT` event is returned instead, skipping execution through all descendants.
 
 ```mermaid
 ---
-title: event.IGNORE (filtering some)
+title: IGNORE_EVENT (filtering some)
 ---
 graph
     cycle1{cycleX}
     cycle1 --> Input1 --> filepath --> Load1 --> cube1 --> Proc
-    cycle1 --> Input2 --> filepath --> Load2 --> event.IGNORE --> Proc
+    cycle1 --> Input2 --> filepath --> Load2 --> IGNORE_EVENT --> Proc
     cycle1 --> Input3 --> filepath --> Load3 --> cube3 --> Proc
-    cycle1 --> Input4 --> filepath --> Load4 --> event.IGNORE --> Proc
+    cycle1 --> Input4 --> filepath --> Load4 --> IGNORE_EVENT --> Proc
     Proc --> cube --> Save
     Proc["Proc (cube1, cube3)"]
 ```
@@ -36,27 +36,26 @@ Here, Input2 and Input4 return an IGNORE event, likely due to there being missin
 Only the non-ignored cubes (`cube1` and `cube3`) reach `Proc`; the ignored inputs are
 dropped.
 
-### `event.SKIP`
-The SKIP event differs from the IGNORE event in that if **any** input to a plugin is a
-SKIP event, node execution is skipped and it instead propagates this skip event so that
+### _SkipEvent: `SKIP_EVENT`
+The skip event differs from the ignore event in that if **any** input to a plugin is 
+`SKIP_EVENT`, node execution is skipped and it instead propagates this skip event so that
 all dependent nodes and their descendants aren't executed.
 
 ```mermaid
 ---
-title: event.SKIP
+title: SKIP_EVENT
 ---
 graph
     cycle1{cycleX}
     cycle1 --> Input1 --> filepath --> Load1 --> cube --> Proc
-    cycle1 --> Input2 --> filepath --> Load2 --> event.SKIP --> Proc
+    cycle1 --> Input2 --> filepath --> Load2 --> SKIP_EVENT --> Proc
     cycle1 --> Input3 --> filepath --> Load3 --> cube --> Proc
-    cycle1 --> Input4 --> filepath --> Load4 --> event.IGNORE --> Proc
-    Proc --> event.SKIP --> Save
+    cycle1 --> Input4 --> filepath --> Load4 --> IGNORE_EVENT --> Proc
+    Proc --> SKIP_EVENT --> Save
 ```
-Because `Input2` returns a SKIP event, the Proc node and everything that follows aren't
+Because `Input2` returns `SKIP_EVENT`, the Proc node and everything that follows aren't
 executed and neither is the Save node since the skip is propagated along the execution
 graph.
-
 """
 
 from dagrunner.utils import Singleton

--- a/dagrunner/events.py
+++ b/dagrunner/events.py
@@ -7,27 +7,28 @@
 DAGrunner defines two special singleton events that plugins can return to control the
 execution flow of their graph.
 
-- IGNORE_EVENT - removes a particular input from further processing.
-- SKIP_EVENT -  aborts the execution of a plugin (and all downstream nodes) when any
+- event.IGNORE - removes a particular input from further processing.
+- event.SKIP -  aborts the execution of a plugin (and all downstream nodes) when any
   input carries this event.
 
 
-### _IgnoreEvent: `IGNORE_EVENT`
-When a plugin returns `IGNORE_EVENT`, the immediate descendant node filters out that
-input. The remaining inputs of that plugin are utilised by that node as normal.
-If all inputs to a node are `IGNORE_EVENT`, the node's execution is skipped, and
-`IGNORE_EVENT` is returned instead.
+### event.IGNORE
+When a plugin returns `event.IGNORE`, the immediate descendant node filters out that
+input.
+The remaining inputs of that plugin are utilised by that node as normal.
+If all inputs to a node are `event.IGNORE`, the node's execution is ignored, and a
+`event.IGNORE` event is returned instead, ignoring execution through all descendants.
 
 ```mermaid
 ---
-title: IGNORE_EVENT (filtering some)
+title: event.IGNORE (filtering some)
 ---
 graph
     cycle1{cycleX}
     cycle1 --> Input1 --> filepath --> Load1 --> cube1 --> Proc
-    cycle1 --> Input2 --> filepath --> Load2 --> IGNORE_EVENT --> Proc
+    cycle1 --> Input2 --> filepath --> Load2 --> event.IGNORE --> Proc
     cycle1 --> Input3 --> filepath --> Load3 --> cube3 --> Proc
-    cycle1 --> Input4 --> filepath --> Load4 --> IGNORE_EVENT --> Proc
+    cycle1 --> Input4 --> filepath --> Load4 --> event.IGNORE --> Proc
     Proc --> cube --> Save
     Proc["Proc (cube1, cube3)"]
 ```
@@ -35,24 +36,24 @@ Here, Input2 and Input4 return an IGNORE event, likely due to there being missin
 Only the non-ignored cubes (`cube1` and `cube3`) reach `Proc`; the ignored inputs are
 dropped.
 
-### _SkipEvent: `SKIP_EVENT`
-The skip event differs from the ignore event in that if **any** input to a plugin is
-`SKIP_EVENT`, node execution is skipped and `SKIP_EVENT` is returned instead. This skip
-propagates so that all dependent nodes and their descendants are not executed.
+### `event.IGNORE`
+The SKIP event differs from the IGNORE event in that if **any** input to a plugin is a
+SKIP event, node execution is skipped and it instead propagates this skip event so that
+all dependent nodes and their descendants aren't executed.
 
 ```mermaid
 ---
-title: SKIP_EVENT
+title: event.SKIP
 ---
 graph
     cycle1{cycleX}
     cycle1 --> Input1 --> filepath --> Load1 --> cube --> Proc
-    cycle1 --> Input2 --> filepath --> Load2 --> SKIP_EVENT --> Proc
+    cycle1 --> Input2 --> filepath --> Load2 --> event.SKIP --> Proc
     cycle1 --> Input3 --> filepath --> Load3 --> cube --> Proc
-    cycle1 --> Input4 --> filepath --> Load4 --> IGNORE_EVENT --> Proc
-    Proc --> SKIP_EVENT --> Save
+    cycle1 --> Input4 --> filepath --> Load4 --> event.IGNORE --> Proc
+    Proc --> event.SKIP --> Save
 ```
-Because `Input2` returns `SKIP_EVENT`, the Proc node and everything that follows aren't
+Because `Input2` returns a SKIP event, the Proc node and everything that follows aren't
 executed and neither is the Save node since the skip is propagated along the execution
 graph.
 """

--- a/dagrunner/events.py
+++ b/dagrunner/events.py
@@ -14,10 +14,9 @@ execution flow of their graph.
 
 ### _IgnoreEvent: `IGNORE_EVENT`
 When a plugin returns `IGNORE_EVENT`, the immediate descendant node filters out that
-input.
-The remaining inputs of that plugin are utilised by that node as normal.
-If all inputs to a node are `IGNORE_EVENT`, the node's execution is skipped, and a
-`SKIP_EVENT` event is returned instead, skipping execution through all descendants.
+input. The remaining inputs of that plugin are utilised by that node as normal.
+If all inputs to a node are `IGNORE_EVENT`, the node's execution is skipped, and
+`IGNORE_EVENT` is returned instead.
 
 ```mermaid
 ---
@@ -37,9 +36,9 @@ Only the non-ignored cubes (`cube1` and `cube3`) reach `Proc`; the ignored input
 dropped.
 
 ### _SkipEvent: `SKIP_EVENT`
-The skip event differs from the ignore event in that if **any** input to a plugin is
-`SKIP_EVENT`, node execution is skipped and it instead propagates this skip event so
-that all dependent nodes and their descendants aren't executed.
+The skip event differs from the ignore event in that if **any** input to a plugin is 
+`SKIP_EVENT`, node execution is skipped and `SKIP_EVENT` is returned instead. This skip
+propagates so that all dependent nodes and their descendants are not executed.
 
 ```mermaid
 ---

--- a/dagrunner/events.py
+++ b/dagrunner/events.py
@@ -37,9 +37,9 @@ Only the non-ignored cubes (`cube1` and `cube3`) reach `Proc`; the ignored input
 dropped.
 
 ### _SkipEvent: `SKIP_EVENT`
-The skip event differs from the ignore event in that if **any** input to a plugin is 
-`SKIP_EVENT`, node execution is skipped and it instead propagates this skip event so that
-all dependent nodes and their descendants aren't executed.
+The skip event differs from the ignore event in that if **any** input to a plugin is
+`SKIP_EVENT`, node execution is skipped and it instead propagates this skip event so
+that all dependent nodes and their descendants aren't executed.
 
 ```mermaid
 ---

--- a/dagrunner/events.py
+++ b/dagrunner/events.py
@@ -36,7 +36,7 @@ Only the non-ignored cubes (`cube1` and `cube3`) reach `Proc`; the ignored input
 dropped.
 
 ### _SkipEvent: `SKIP_EVENT`
-The skip event differs from the ignore event in that if **any** input to a plugin is 
+The skip event differs from the ignore event in that if **any** input to a plugin is
 `SKIP_EVENT`, node execution is skipped and `SKIP_EVENT` is returned instead. This skip
 propagates so that all dependent nodes and their descendants are not executed.
 

--- a/dagrunner/events.py
+++ b/dagrunner/events.py
@@ -36,7 +36,7 @@ Here, Input2 and Input4 return an IGNORE event, likely due to there being missin
 Only the non-ignored cubes (`cube1` and `cube3`) reach `Proc`; the ignored inputs are
 dropped.
 
-### `event.IGNORE`
+### `event.SKIP`
 The SKIP event differs from the IGNORE event in that if **any** input to a plugin is a
 SKIP event, node execution is skipped and it instead propagates this skip event so that
 all dependent nodes and their descendants aren't executed.

--- a/dagrunner/execute_graph.py
+++ b/dagrunner/execute_graph.py
@@ -152,7 +152,7 @@ def plugin_executor(
     if len(args) > 0 and all((map(lambda x: x is events.IGNORE_EVENT, args))):
         # all args are IGNORE_EVENT, return IGNORE_EVENT (pass along)
         if verbose:
-            print(f"Retuning 'IGNORE_EVENT' event {call[0]}")
+            print(f"Returning 'IGNORE_EVENT' event {call[0]}")
         return events.IGNORE_EVENT
     args = list(filter(lambda x: x is not events.IGNORE_EVENT, args))
 

--- a/dagrunner/execute_graph.py
+++ b/dagrunner/execute_graph.py
@@ -149,7 +149,7 @@ def plugin_executor(
     call = as_iterable(call)
 
     # IGNORE_EVENT event handling
-    if len(args) > 1 and all((map(lambda x: x is events.IGNORE_EVENT, args))):
+    if len(args) > 0 and all((map(lambda x: x is events.IGNORE_EVENT, args))):
         # all args are IGNORE_EVENT, return IGNORE_EVENT (pass along)
         if verbose:
             print(f"Retuning 'IGNORE_EVENT' event {call[0]}")

--- a/dagrunner/plugin_framework.py
+++ b/dagrunner/plugin_framework.py
@@ -144,7 +144,7 @@ class Load(Plugin):
             raise ValueError(
                 "Staging directory must be specified for loading remote files."
             )
-        
+
         try:
             if self._staging_dir and args:
                 args = stage_to_dir(
@@ -157,8 +157,8 @@ class Load(Plugin):
                         f"No such file or directory: {', '.join(missing_files)}"
                     )
                 elif len(args) == 0:
-                    raise ValueError(f"Empty input arguments")
-                
+                    raise ValueError("Empty input arguments")
+
         except (FileNotFoundError, ValueError) as e:
             if self._on_missing == "error":
                 raise e

--- a/dagrunner/plugin_framework.py
+++ b/dagrunner/plugin_framework.py
@@ -150,14 +150,14 @@ class Load(Plugin):
                 args = stage_to_dir(
                     *args, staging_dir=self._staging_dir, verbose=self._verbose
                 )
+            elif not args:
+                raise ValueError("Empty input arguments")
             else:
                 missing_files = list(filter(lambda fpath: not glob(fpath), args))
                 if missing_files:
                     raise FileNotFoundError(
                         f"No such file or directory: {', '.join(missing_files)}"
                     )
-                elif len(args) == 0:
-                    raise ValueError("Empty input arguments")
 
         except (FileNotFoundError, ValueError) as e:
             if self._on_missing == "error":

--- a/dagrunner/plugin_framework.py
+++ b/dagrunner/plugin_framework.py
@@ -157,16 +157,16 @@ class Load(Plugin):
                         f"No such file or directory: {', '.join(missing_files)}"
                     )
                 elif len(args) == 0:
-                    raise ValueError(f"Empty input arguments.")
+                    raise ValueError(f"Empty input arguments")
                 
         except (FileNotFoundError, ValueError) as e:
             if self._on_missing == "error":
                 raise e
             elif self._on_missing == "ignore":
-                warnings.warn(str(e) + " Ignoring node.")
+                warnings.warn(str(e) + "\nIgnoring node.")
                 return events.IGNORE_EVENT
             elif self._on_missing == "skip":
-                warnings.warn(str(e) + " Skipping node")
+                warnings.warn(str(e) + "\nSkipping node.")
                 return events.SKIP_EVENT
             else:
                 raise ValueError(

--- a/dagrunner/plugin_framework.py
+++ b/dagrunner/plugin_framework.py
@@ -133,10 +133,10 @@ class Load(Plugin):
         Raises:
         - FileNotFoundError: If any of the files do not exist and `on_missing` is set
           to 'error'.
-        - ValueError: If `on_missing` is set to an invalid value.
+        - ValueError: If no args provided or `on_missing` is set to an invalid value.
 
         """
-        args = list(map(process_path, args))
+        args = list(map(process_path, args))   
         if (
             any([arg.split(":")[0] for arg in args if ":" in arg])
             and self._staging_dir is None
@@ -150,16 +150,13 @@ class Load(Plugin):
                 args = stage_to_dir(
                     *args, staging_dir=self._staging_dir, verbose=self._verbose
                 )
-            elif not args:
-                raise ValueError("Empty input arguments")
             else:
                 missing_files = list(filter(lambda fpath: not glob(fpath), args))
                 if missing_files:
                     raise FileNotFoundError(
                         f"No such file or directory: {', '.join(missing_files)}"
                     )
-
-        except (FileNotFoundError, ValueError) as e:
+        except FileNotFoundError as e:
             if self._on_missing == "error":
                 raise e
             elif self._on_missing == "ignore":

--- a/dagrunner/plugin_framework.py
+++ b/dagrunner/plugin_framework.py
@@ -163,10 +163,10 @@ class Load(Plugin):
             if self._on_missing == "error":
                 raise e
             elif self._on_missing == "ignore":
-                warnings.warn(str(e) + "\nIgnoring node.")
+                warnings.warn(f"Ignoring node due to error {str(e)!r}")
                 return events.IGNORE_EVENT
             elif self._on_missing == "skip":
-                warnings.warn(str(e) + "\nSkipping node.")
+                warnings.warn(f"Skipping node due to error {str(e)!r}")
                 return events.SKIP_EVENT
             else:
                 raise ValueError(

--- a/dagrunner/plugin_framework.py
+++ b/dagrunner/plugin_framework.py
@@ -133,6 +133,7 @@ class Load(Plugin):
         Raises:
         - FileNotFoundError: If any of the files do not exist and `on_missing` is set
           to 'error'.
+        - ValueError: If `on_missing` is set to an invalid value.
 
         """
         args = list(map(process_path, args))
@@ -143,7 +144,7 @@ class Load(Plugin):
             raise ValueError(
                 "Staging directory must be specified for loading remote files."
             )
-
+        
         try:
             if self._staging_dir and args:
                 args = stage_to_dir(
@@ -155,21 +156,23 @@ class Load(Plugin):
                     raise FileNotFoundError(
                         f"No such file or directory: {', '.join(missing_files)}"
                     )
-        except FileNotFoundError as e:
+                elif len(args) == 0:
+                    raise ValueError(f"Empty input arguments.")
+                
+        except (FileNotFoundError, ValueError) as e:
             if self._on_missing == "error":
                 raise e
             elif self._on_missing == "ignore":
-                warnings.warn(str(e))
+                warnings.warn(str(e) + " Ignoring node.")
                 return events.IGNORE_EVENT
             elif self._on_missing == "skip":
-                warnings.warn(str(e))
+                warnings.warn(str(e) + " Skipping node")
                 return events.SKIP_EVENT
             else:
                 raise ValueError(
                     f"Invalid value for 'on_missing': {self._on_missing}. "
                     "Accepted values are 'error', 'ignore', and 'skip'."
                 )
-
         return self.load(*args, **kwargs)
 
 

--- a/dagrunner/plugin_framework.py
+++ b/dagrunner/plugin_framework.py
@@ -162,10 +162,10 @@ class Load(Plugin):
             if self._on_missing == "error":
                 raise e
             elif self._on_missing == "ignore":
-                warnings.warn(f"Ignoring node due to caught exception {str(e)!r}")
+                warnings.warn(f"Ignoring node - {str(e)}")
                 return events.IGNORE_EVENT
             elif self._on_missing == "skip":
-                warnings.warn(f"Skipping node due to caught exception {str(e)!r}")
+                warnings.warn(f"Skipping node - {str(e)}")
                 return events.SKIP_EVENT
             else:
                 raise ValueError(

--- a/dagrunner/plugin_framework.py
+++ b/dagrunner/plugin_framework.py
@@ -163,10 +163,10 @@ class Load(Plugin):
             if self._on_missing == "error":
                 raise e
             elif self._on_missing == "ignore":
-                warnings.warn(f"Ignoring node due to error {str(e)!r}")
+                warnings.warn(f"Ignoring node due to caught exception {str(e)!r}")
                 return events.IGNORE_EVENT
             elif self._on_missing == "skip":
-                warnings.warn(f"Skipping node due to error {str(e)!r}")
+                warnings.warn(f"Skipping node due to caught exception {str(e)!r}")
                 return events.SKIP_EVENT
             else:
                 raise ValueError(

--- a/dagrunner/plugin_framework.py
+++ b/dagrunner/plugin_framework.py
@@ -8,7 +8,6 @@ import os
 import pickle
 import string
 import subprocess
-import warnings
 from abc import ABC, abstractmethod
 from glob import glob
 

--- a/dagrunner/plugin_framework.py
+++ b/dagrunner/plugin_framework.py
@@ -133,12 +133,10 @@ class Load(Plugin):
         Raises:
         - FileNotFoundError: If any of the files do not exist and `on_missing` is set
           to 'error'.
-        - ValueError: If no args provided or `on_missing` is set to an invalid value.
+        - ValueError: If `on_missing` is set to an invalid value.
 
         """
         args = list(map(process_path, args))
-        if not args:
-            raise ValueError(f"Invalid input arguments: {args}")  
         if (
             any([arg.split(":")[0] for arg in args if ":" in arg])
             and self._staging_dir is None
@@ -162,10 +160,10 @@ class Load(Plugin):
             if self._on_missing == "error":
                 raise e
             elif self._on_missing == "ignore":
-                warnings.warn(f"Ignoring node - {str(e)}")
+                warnings.warn(f"Ignoring load - {str(e)}")
                 return events.IGNORE_EVENT
             elif self._on_missing == "skip":
-                warnings.warn(f"Skipping node - {str(e)}")
+                warnings.warn(f"Skipping load - {str(e)}")
                 return events.SKIP_EVENT
             else:
                 raise ValueError(

--- a/dagrunner/plugin_framework.py
+++ b/dagrunner/plugin_framework.py
@@ -136,7 +136,9 @@ class Load(Plugin):
         - ValueError: If no args provided or `on_missing` is set to an invalid value.
 
         """
-        args = list(map(process_path, args))   
+        args = list(map(process_path, args))
+        if not args:
+            raise ValueError(f"Invalid input arguments: {args}")  
         if (
             any([arg.split(":")[0] for arg in args if ":" in arg])
             and self._staging_dir is None

--- a/dagrunner/plugin_framework.py
+++ b/dagrunner/plugin_framework.py
@@ -160,10 +160,8 @@ class Load(Plugin):
             if self._on_missing == "error":
                 raise e
             elif self._on_missing == "ignore":
-                warnings.warn(f"Ignoring load - {str(e)}")
                 return events.IGNORE_EVENT
             elif self._on_missing == "skip":
-                warnings.warn(f"Skipping load - {str(e)}")
                 return events.SKIP_EVENT
             else:
                 raise ValueError(

--- a/dagrunner/tests/execute_graph/test_plugin_executor.py
+++ b/dagrunner/tests/execute_graph/test_plugin_executor.py
@@ -119,10 +119,22 @@ def test_ignore_event():
     assert res == IGNORE_EVENT
 
 
+def test_ignore_event_single_input():
+    """Check what happens when the sole argument is IGNORE_EVENT."""
+    res = plugin_executor(*(IGNORE_EVENT,), call=())
+    assert res == IGNORE_EVENT
+
+
 def test_skip_event():
     """Check what happens a subset of arguments are SKIP_EVENT."""
     call = tuple([lambda x: x + 5])
     res = plugin_executor(*(5, SKIP_EVENT), call=call)
+    assert res == SKIP_EVENT
+
+
+def test_skip_event_single_input():
+    """Check what happens when the sole argument is SKIP_EVENT."""
+    res = plugin_executor(*(SKIP_EVENT,), call=())
     assert res == SKIP_EVENT
 
 

--- a/dagrunner/tests/execute_graph/test_plugin_executor.py
+++ b/dagrunner/tests/execute_graph/test_plugin_executor.py
@@ -137,16 +137,11 @@ def test_ignore_event(args, expected):
     assert res == expected
 
 
-def test_skip_event():
-    """Check what happens a subset of arguments are SKIP_EVENT."""
+@pytest.mark.parametrize("args", [(5, SKIP_EVENT), (SKIP_EVENT,)])
+def test_skip_event(args):
+    """Check what happens when any input argument is SKIP_EVENT."""
     call = tuple([lambda x: x + 5])
-    res = plugin_executor(*(5, SKIP_EVENT), call=call)
-    assert res == SKIP_EVENT
-
-
-def test_skip_event_single_input():
-    """Check what happens when the sole argument is SKIP_EVENT."""
-    res = plugin_executor(*(SKIP_EVENT,), call=())
+    res = plugin_executor(*args, call=call)
     assert res == SKIP_EVENT
 
 

--- a/dagrunner/tests/execute_graph/test_plugin_executor.py
+++ b/dagrunner/tests/execute_graph/test_plugin_executor.py
@@ -122,7 +122,19 @@ def test_ignore_event():
 def test_ignore_event_single_input():
     """Check what happens when the sole argument is IGNORE_EVENT."""
     res = plugin_executor(*(IGNORE_EVENT,), call=())
-    assert res == IGNORE_EVENT
+@pytest.mark.parametrize(
+    "args, expected",
+    [
+        ((5, IGNORE_EVENT), 10),
+        ((IGNORE_EVENT, IGNORE_EVENT), IGNORE_EVENT),
+        ((IGNORE_EVENT,), IGNORE_EVENT),
+    ],
+)
+def test_ignore_event(args, expected):
+    """Check IGNORE_EVENT behaviour across mixed, all, and single-input cases."""
+    call = tuple([lambda x: x + 5])
+    res = plugin_executor(*args, call=call)
+    assert res == expected
 
 
 def test_skip_event():

--- a/dagrunner/tests/execute_graph/test_plugin_executor.py
+++ b/dagrunner/tests/execute_graph/test_plugin_executor.py
@@ -119,9 +119,6 @@ def test_ignore_event():
     assert res == IGNORE_EVENT
 
 
-def test_ignore_event_single_input():
-    """Check what happens when the sole argument is IGNORE_EVENT."""
-    res = plugin_executor(*(IGNORE_EVENT,), call=())
 @pytest.mark.parametrize(
     "args, expected",
     [

--- a/dagrunner/tests/execute_graph/test_plugin_executor.py
+++ b/dagrunner/tests/execute_graph/test_plugin_executor.py
@@ -109,16 +109,6 @@ def test_pass_class_arg_kwargs(plugin, init_args, call_args, target):
     assert res == target
 
 
-def test_ignore_event():
-    """Check what happens a subset of arguments and all arguments are IGNORE_EVENT."""
-    call = tuple([lambda x: x + 5])
-    res = plugin_executor(*(5, IGNORE_EVENT), call=call)
-    assert res == 10
-
-    res = plugin_executor(*(IGNORE_EVENT, IGNORE_EVENT), call=call)
-    assert res == IGNORE_EVENT
-
-
 @pytest.mark.parametrize(
     "args, expected",
     [

--- a/dagrunner/tests/plugin_framework/test_LoadJson.py
+++ b/dagrunner/tests/plugin_framework/test_LoadJson.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 
 import pytest
 
-from dagrunner.events import IGNORE_EVENT, SKIP_EVENT
+from dagrunner.events import IGNORE_EVENT, SKIP_EVENT, _EventBase
 from dagrunner.plugin_framework import LoadJson
 
 
@@ -50,17 +50,11 @@ def test_missing_data_skip():
     assert LoadJson(on_missing="skip")("dummy-file") == SKIP_EVENT
 
 
-def test_empty_args_error():
-    with pytest.raises(ValueError, match="Empty input arguments"):
-        LoadJson(on_missing="error")()
-
-
-def test_empty_args_ignore():
-    assert LoadJson(on_missing="ignore")() == IGNORE_EVENT
-
-
-def test_empty_args_skip():
-    assert LoadJson(on_missing="skip")() == SKIP_EVENT
+@pytest.mark.parametrize("on_missing", [None, "error", "skip", "ignore"])
+def test_empty_args(on_missing: str | None):
+    plugin = LoadJson(on_missing=on_missing) if on_missing else LoadJson()
+    with pytest.raises(ValueError, match="Invalid input arguments"):
+        plugin()
 
 
 def test_missing_data_unknown():

--- a/dagrunner/tests/plugin_framework/test_LoadJson.py
+++ b/dagrunner/tests/plugin_framework/test_LoadJson.py
@@ -50,6 +50,19 @@ def test_missing_data_skip():
     assert LoadJson(on_missing="skip")("dummy-file") == SKIP_EVENT
 
 
+def test_empty_args_error():
+    with pytest.raises(ValueError, match="Empty input arguments"):
+        LoadJson(on_missing="error")()
+
+
+def test_empty_args_ignore():
+    assert LoadJson(on_missing="ignore")() == IGNORE_EVENT
+
+
+def test_empty_args_skip():
+    assert LoadJson(on_missing="skip")() == SKIP_EVENT
+
+
 def test_missing_data_unknown():
     with pytest.raises(
         ValueError,

--- a/dagrunner/tests/plugin_framework/test_LoadJson.py
+++ b/dagrunner/tests/plugin_framework/test_LoadJson.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 
 import pytest
 
-from dagrunner.events import IGNORE_EVENT, SKIP_EVENT, _EventBase
+from dagrunner.events import IGNORE_EVENT, SKIP_EVENT
 from dagrunner.plugin_framework import LoadJson
 
 

--- a/dagrunner/tests/plugin_framework/test_LoadJson.py
+++ b/dagrunner/tests/plugin_framework/test_LoadJson.py
@@ -50,13 +50,6 @@ def test_missing_data_skip():
     assert LoadJson(on_missing="skip")("dummy-file") == SKIP_EVENT
 
 
-@pytest.mark.parametrize("on_missing", [None, "error", "skip", "ignore"])
-def test_empty_args(on_missing: str | None):
-    plugin = LoadJson(on_missing=on_missing) if on_missing else LoadJson()
-    with pytest.raises(ValueError, match="Invalid input arguments"):
-        plugin()
-
-
 def test_missing_data_unknown():
     with pytest.raises(
         ValueError,

--- a/docs/dagrunner.events.md
+++ b/docs/dagrunner.events.md
@@ -6,28 +6,28 @@
 DAGrunner defines two special singleton events that plugins can return to control the
 execution flow of their graph.
 
-- event.IGNORE - removes a particular input from further processing.
-- event.SKIP -  aborts the execution of a plugin (and all downstream nodes) when any
+- IGNORE_EVENT - removes a particular input from further processing.
+- SKIP_EVENT -  aborts the execution of a plugin (and all downstream nodes) when any
   input carries this event.
 
 
-### event.IGNORE
-When a plugin returns `event.IGNORE`, the immediate descendant node filters out that
+### _IgnoreEvent: `IGNORE_EVENT`
+When a plugin returns `IGNORE_EVENT`, the immediate descendant node filters out that
 input.
 The remaining inputs of that plugin are utilised by that node as normal.
-If all inputs to a node are `event.IGNORE`, the node's execution is skipped, and a
-`event.SKIP` event is returned instead, skipping execution through all descendants.
+If all inputs to a node are `IGNORE_EVENT`, the node's execution is skipped, and a
+`SKIP_EVENT` event is returned instead, skipping execution through all descendants.
 
 ```mermaid
 ---
-title: event.IGNORE (filtering some)
+title: IGNORE_EVENT (filtering some)
 ---
 graph
     cycle1{cycleX}
     cycle1 --> Input1 --> filepath --> Load1 --> cube1 --> Proc
-    cycle1 --> Input2 --> filepath --> Load2 --> event.IGNORE --> Proc
+    cycle1 --> Input2 --> filepath --> Load2 --> IGNORE_EVENT --> Proc
     cycle1 --> Input3 --> filepath --> Load3 --> cube3 --> Proc
-    cycle1 --> Input4 --> filepath --> Load4 --> event.IGNORE --> Proc
+    cycle1 --> Input4 --> filepath --> Load4 --> IGNORE_EVENT --> Proc
     Proc --> cube --> Save
     Proc["Proc (cube1, cube3)"]
 ```
@@ -35,30 +35,25 @@ Here, Input2 and Input4 return an IGNORE event, likely due to there being missin
 Only the non-ignored cubes (`cube1` and `cube3`) reach `Proc`; the ignored inputs are
 dropped.
 
-### `event.SKIP`
-The SKIP event differs from the IGNORE event in that if **any** input to a plugin is a
-SKIP event, node execution is skipped and it instead propagates this skip event so that
+### _SkipEvent: `SKIP_EVENT`
+The skip event differs from the ignore event in that if **any** input to a plugin is 
+`SKIP_EVENT`, node execution is skipped and it instead propagates this skip event so that
 all dependent nodes and their descendants aren't executed.
 
 ```mermaid
 ---
-title: event.SKIP
+title: SKIP_EVENT
 ---
 graph
     cycle1{cycleX}
     cycle1 --> Input1 --> filepath --> Load1 --> cube --> Proc
-    cycle1 --> Input2 --> filepath --> Load2 --> event.SKIP --> Proc
+    cycle1 --> Input2 --> filepath --> Load2 --> SKIP_EVENT --> Proc
     cycle1 --> Input3 --> filepath --> Load3 --> cube --> Proc
-    cycle1 --> Input4 --> filepath --> Load4 --> event.IGNORE --> Proc
-    Proc --> event.SKIP --> Save
+    cycle1 --> Input4 --> filepath --> Load4 --> IGNORE_EVENT --> Proc
+    Proc --> SKIP_EVENT --> Save
 ```
-Because `Input2` returns a SKIP event, the Proc node and everything that follows aren't
+Because `Input2` returns `SKIP_EVENT`, the Proc node and everything that follows aren't
 executed and neither is the Save node since the skip is propagated along the execution
 graph.
 
 see [class: dagrunner.utils.Singleton](dagrunner.utils.md#class-singleton)
-
-## _IgnoreEvent: `IGNORE_EVENT`
-
-## _SkipEvent: `SKIP_EVENT`
-

--- a/docs/dagrunner.events.md
+++ b/docs/dagrunner.events.md
@@ -35,7 +35,7 @@ Here, Input2 and Input4 return an IGNORE event, likely due to there being missin
 Only the non-ignored cubes (`cube1` and `cube3`) reach `Proc`; the ignored inputs are
 dropped.
 
-### `event.IGNORE`
+### `event.SKIP`
 The SKIP event differs from the IGNORE event in that if **any** input to a plugin is a
 SKIP event, node execution is skipped and it instead propagates this skip event so that
 all dependent nodes and their descendants aren't executed.

--- a/docs/dagrunner.events.md
+++ b/docs/dagrunner.events.md
@@ -6,27 +6,28 @@
 DAGrunner defines two special singleton events that plugins can return to control the
 execution flow of their graph.
 
-- IGNORE_EVENT - removes a particular input from further processing.
-- SKIP_EVENT -  aborts the execution of a plugin (and all downstream nodes) when any
+- event.IGNORE - removes a particular input from further processing.
+- event.SKIP -  aborts the execution of a plugin (and all downstream nodes) when any
   input carries this event.
 
 
-### _IgnoreEvent: `IGNORE_EVENT`
-When a plugin returns `IGNORE_EVENT`, the immediate descendant node filters out that
-input. The remaining inputs of that plugin are utilised by that node as normal.
-If all inputs to a node are `IGNORE_EVENT`, the node's execution is skipped, and
-`IGNORE_EVENT` is returned instead.
+### event.IGNORE
+When a plugin returns `event.IGNORE`, the immediate descendant node filters out that
+input.
+The remaining inputs of that plugin are utilised by that node as normal.
+If all inputs to a node are `event.IGNORE`, the node's execution is ignored, and a
+`event.IGNORE` event is returned instead, ignoring execution through all descendants.
 
 ```mermaid
 ---
-title: IGNORE_EVENT (filtering some)
+title: event.IGNORE (filtering some)
 ---
 graph
     cycle1{cycleX}
     cycle1 --> Input1 --> filepath --> Load1 --> cube1 --> Proc
-    cycle1 --> Input2 --> filepath --> Load2 --> IGNORE_EVENT --> Proc
+    cycle1 --> Input2 --> filepath --> Load2 --> event.IGNORE --> Proc
     cycle1 --> Input3 --> filepath --> Load3 --> cube3 --> Proc
-    cycle1 --> Input4 --> filepath --> Load4 --> IGNORE_EVENT --> Proc
+    cycle1 --> Input4 --> filepath --> Load4 --> event.IGNORE --> Proc
     Proc --> cube --> Save
     Proc["Proc (cube1, cube3)"]
 ```
@@ -34,25 +35,29 @@ Here, Input2 and Input4 return an IGNORE event, likely due to there being missin
 Only the non-ignored cubes (`cube1` and `cube3`) reach `Proc`; the ignored inputs are
 dropped.
 
-### _SkipEvent: `SKIP_EVENT`
-The skip event differs from the ignore event in that if **any** input to a plugin is 
-`SKIP_EVENT`, node execution is skipped and `SKIP_EVENT` is returned instead. This skip
-propagates so that all dependent nodes and their descendants are not executed.
+### `event.IGNORE`
+The SKIP event differs from the IGNORE event in that if **any** input to a plugin is a
+SKIP event, node execution is skipped and it instead propagates this skip event so that
+all dependent nodes and their descendants aren't executed.
 
 ```mermaid
 ---
-title: SKIP_EVENT
+title: event.SKIP
 ---
 graph
     cycle1{cycleX}
     cycle1 --> Input1 --> filepath --> Load1 --> cube --> Proc
-    cycle1 --> Input2 --> filepath --> Load2 --> SKIP_EVENT --> Proc
+    cycle1 --> Input2 --> filepath --> Load2 --> event.SKIP --> Proc
     cycle1 --> Input3 --> filepath --> Load3 --> cube --> Proc
-    cycle1 --> Input4 --> filepath --> Load4 --> IGNORE_EVENT --> Proc
-    Proc --> SKIP_EVENT --> Save
+    cycle1 --> Input4 --> filepath --> Load4 --> event.IGNORE --> Proc
+    Proc --> event.SKIP --> Save
 ```
-Because `Input2` returns `SKIP_EVENT`, the Proc node and everything that follows aren't
+Because `Input2` returns a SKIP event, the Proc node and everything that follows aren't
 executed and neither is the Save node since the skip is propagated along the execution
 graph.
 
 see [class: dagrunner.utils.Singleton](dagrunner.utils.md#class-singleton)
+
+## _IgnoreEvent: `IGNORE_EVENT`
+
+## _SkipEvent: `SKIP_EVENT`

--- a/docs/dagrunner.events.md
+++ b/docs/dagrunner.events.md
@@ -13,10 +13,9 @@ execution flow of their graph.
 
 ### _IgnoreEvent: `IGNORE_EVENT`
 When a plugin returns `IGNORE_EVENT`, the immediate descendant node filters out that
-input.
-The remaining inputs of that plugin are utilised by that node as normal.
-If all inputs to a node are `IGNORE_EVENT`, the node's execution is skipped, and a
-`SKIP_EVENT` event is returned instead, skipping execution through all descendants.
+input. The remaining inputs of that plugin are utilised by that node as normal.
+If all inputs to a node are `IGNORE_EVENT`, the node's execution is skipped, and
+`IGNORE_EVENT` is returned instead.
 
 ```mermaid
 ---
@@ -37,8 +36,8 @@ dropped.
 
 ### _SkipEvent: `SKIP_EVENT`
 The skip event differs from the ignore event in that if **any** input to a plugin is 
-`SKIP_EVENT`, node execution is skipped and it instead propagates this skip event so that
-all dependent nodes and their descendants aren't executed.
+`SKIP_EVENT`, node execution is skipped and `SKIP_EVENT` is returned instead. This skip
+propagates so that all dependent nodes and their descendants are not executed.
 
 ```mermaid
 ---


### PR DESCRIPTION
[Parent ticket](https://metoffice.atlassian.net/browse/EPPT-3516)
[Child ticket](https://metoffice.atlassian.net/browse/EPPT-3522)
[epp_workflows PR that requires these changes](https://github.com/MetOffice/epp_workflows/pull/561)

### Allow DAGrunner to propagate an `IGNORE_EVENT` with only one input argument

Previously: _Allow DAGrunner to handle an empty set of arguments passed to `Load` / EPPT-3522 FSI fails without monow_

_These changes are part of a fix to the EPP fire severity index (FSI) workflow to produce outputs when MONOW input data is unavailable._

<!-- - Allow an empty set of arguments to `Load` to trigger the return of an event or error, depending on the value of `on_missing`. This allows DAGrunner to handle the situation where EPP `input_latest` plugin returns `None` when it cannot find a file (OUTDATED). -->
- Allow nodes with only one input to return an ignore event. This allows chains of nodes with single inputs to be correctly ignored. 
  - For example, before this change, when a standardise immediately followed a load in the FSI workflow, if the load node (51) was ignored, the standardise node (52) would throw an error because it received no cubes.
<p align="center">
<img width="250" height="350" alt="image" src="https://github.com/user-attachments/assets/ac3db3cd-abad-4976-9690-58f43baf027f" />
</p>

- Update events documentation.
- New unit tests.