### PR TITLE
pre-commit: zizmor usage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Reference:
+# - https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/keeping-your-actions-up-to-date-with-dependabot
+# - https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "bot"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,9 @@ name: Pull Request Tests
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 
 jobs:
   pre-commit:
@@ -12,10 +15,12 @@ jobs:
       # SETUP
       ############################
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
         with:
           python-version: 3.x
           cache: 'pip'
@@ -35,7 +40,7 @@ jobs:
         run: echo "PYSHA=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
 
       - name: Cache pre-commit
-        uses: actions/cache@v3
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         id: pre-commit-cache
         with:
           path: ~/.cache/pre-commit
@@ -58,10 +63,12 @@ jobs:
       # SETUP
       ############################
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
         with:
           python-version: 3.9
           cache: 'pip'
@@ -96,10 +103,12 @@ jobs:
       # SETUP
       ############################
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
         with:
           python-version: 3.9
           cache: 'pip'
@@ -145,10 +154,12 @@ jobs:
       # SETUP
       ############################
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
         with:
           python-version: 3.x
           cache: 'pip'
@@ -178,15 +189,16 @@ jobs:
       ############################
       - name: Cache ref branch coverage report
         id: cache-ref-coverage
-        uses: actions/cache@v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
         with:
           path: ref/coverage_output.txt
           key: ref-${{ github.event.pull_request.base.sha }}
 
       - name: Checkout ref branch
         if: steps.cache-ref-coverage.outputs.cache-hit != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
+          persist-credentials: false
           path: ref
           ref: ${{ github.base_ref }}
 
@@ -203,7 +215,7 @@ jobs:
         run: |
           set -e
           # ----- USER SETTINGS -------------------------------------------------
-          CHECK_MISS_TOL=1      # 1 = evaluate the miss‑count difference, 0 = ignore it
+          CHECK_MISS_TOL=1      # 1 = evaluate the miss-count difference, 0 = ignore it
           CHECK_PERC_TOL=0      # 1 = evaluate the percentage difference, 0 = ignore it
 
           # Tolerances
@@ -252,7 +264,7 @@ jobs:
 
       - name: Upload coverage report
         if: steps.comp-coverage.outputs.coverage_decreased == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: coverage-report-pr
           path: |
@@ -265,10 +277,17 @@ jobs:
             echo "Code coverage has decreased"
             echo "-----------------------------------------------"
             echo -e "Coverage totals\tstatements\tmissed\n\
-            PR\t${{ steps.comp-coverage.outputs.pr_tot_stmts }}\t${{ steps.comp-coverage.outputs.pr_tot_miss }}\t${{ steps.comp-coverage.outputs.pr_perc_total }}%\n\
-            Reference\t${{ steps.comp-coverage.outputs.ref_tot_stmts }}\t${{ steps.comp-coverage.outputs.ref_tot_miss }}\t${{ steps.comp-coverage.outputs.ref_perc_total }}%" \
+            PR\t${PR_TOT_STMTS}\t${PR_TOT_MISS}\t${PR_PERC_TOTAL}%\n\
+            Reference\t${REF_TOT_STMTS}\t${REF_TOT_MISS}\t${REF_PERC_TOTAL}%" \
             | column -t -s $'\t'
             echo "-----------------------------------------------"
             echo "Report uploaded as artifact 'coverage-report-pr'"
             echo "Test coverage failure is non-blocking, but please consider improving test coverage before merging."
             exit 1
+        env:
+          PR_TOT_STMTS: ${{ steps.comp-coverage.outputs.pr_tot_stmts }}
+          PR_TOT_MISS: ${{ steps.comp-coverage.outputs.pr_tot_miss }}
+          PR_PERC_TOTAL: ${{ steps.comp-coverage.outputs.pr_perc_total }}
+          REF_TOT_STMTS: ${{ steps.comp-coverage.outputs.ref_tot_stmts }}
+          REF_TOT_MISS: ${{ steps.comp-coverage.outputs.ref_tot_miss }}
+          REF_PERC_TOTAL: ${{ steps.comp-coverage.outputs.ref_perc_total }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,8 @@ repos:
       files: '\.py$'
       language: system
       entry: ./copyright_check
+- repo: https://github.com/zizmorcore/zizmor-pre-commit
+  rev: v1.28.0
+  hooks:
+    - id: zizmor
+      args: [--fix]


### PR DESCRIPTION
zizmor is a static analysis tool for CI/CD.
"It can find and fix security issues in common CI/CD setups, including GitHub Actions, Dependabot, and pre-commit."

Official docs: https://docs.zizmor.sh/integrations/
pre-commit: https://github.com/zizmorcore/zizmor-pre-commit

Can be integrated with github [CI itself](https://docs.zizmor.sh/integrations/#github-actions) but opted for pre-commit which we have running via github CI workflow anyway instead. 